### PR TITLE
Send messages via PM

### DIFF
--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -112,13 +112,15 @@ def execute_tasks(
         print("No active channels")
         return
     local_config = read_local_config(local_config_path)
+    digester = Digester(local_config["path"]["lang"])
     connection = Connection(local_config, database.get_supported_wikis())
     get_global_config(local_config, database, connection)
     get_user_config(local_config, database, connection)
+    # Refresh the connection to add any newly-configured wikis
+    connection = Connection(local_config, database.get_supported_wikis())
     get_new_posts(database, connection)
     # Record the 'current' timestamp immediately after downloading posts
     current_timestamp = int(time.time())
-    digester = Digester(local_config["path"]["lang"])
     connection.login(local_config["wikidot_username"], wikidot_password)
     # If there's at least one user subscribed via email, get the list of
     # emails from the notification account's back-contacts

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -63,7 +63,7 @@ class NotificationChannel(ABC):
                 continue
             # Send the digests via PM to PM-subscribed users
             if user["delivery"] == "pm":
-                connection.send_message(user["username"], subject, body)
+                connection.send_message(user["user_id"], subject, body)
             # Send the digests via email to email-subscribed users
             if user["delivery"] == "email":
                 try:

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -112,7 +112,7 @@ def execute_tasks(
         print("No active channels")
         return
     local_config = read_local_config(local_config_path)
-    connection = Connection()
+    connection = Connection(database.get_supported_wikis())
     get_global_config(local_config, database, connection)
     get_user_config(local_config, database, connection)
     get_new_posts(database, connection)

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -112,7 +112,7 @@ def execute_tasks(
         print("No active channels")
         return
     local_config = read_local_config(local_config_path)
-    connection = Connection(database.get_supported_wikis())
+    connection = Connection(local_config, database.get_supported_wikis())
     get_global_config(local_config, database, connection)
     get_user_config(local_config, database, connection)
     get_new_posts(database, connection)

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -230,6 +230,22 @@ class Connection:
             ),
         )
 
+    def send_message(self, user_id: str, subject: str, body: str) -> None:
+        """Send a Wikidot message to the given user with the given subject
+        and body.
+
+        The Wikidot connection must be logged-in.
+        """
+        self.module(
+            "www",
+            "Empty",
+            action="DashboardMessageAction",
+            event="send",
+            to_user_id=user_id,
+            subject=subject,
+            source=body,
+        )
+
     def get_contacts(self) -> EmailAddresses:
         """Get the account's contacts list and their emails in order to be
         able to send email notifications.

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -34,12 +34,10 @@ class Connection:
 
     def module(self, wiki: str, module_name: str, **kwargs) -> WikidotResponse:
         """Call a Wikidot module."""
+        token7 = self._session.cookies.get("wikidot_token7")
         response = self.post(
-            "http://{}.wikidot.com/ajax-module-connector.php".format(wiki),
-            data=dict(
-                moduleName=module_name, wikidot_token7="123456", **kwargs
-            ),
-            cookies={"wikidot_token7": "123456"},
+            f"http://{wiki}.wikidot.com/ajax-module-connector.php",
+            data=dict(moduleName=module_name, wikidot_token7=token7, **kwargs),
         ).json()
         if response["status"] != "ok":
             raise RuntimeError(response.get("message") or response["status"])

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Iterator, Optional, Union, cast
+from typing import Iterable, Iterator, List, Optional, Union, cast
 
 import requests
 from bs4 import BeautifulSoup
@@ -9,6 +9,7 @@ from notifier.types import (
     EmailAddresses,
     RawPost,
     RawThreadMeta,
+    SupportedWikiConfig,
     WikidotResponse,
 )
 
@@ -24,9 +25,14 @@ listpages_div_wrap = f"""
 class Connection:
     """Connection to Wikidot facilitating communications with it."""
 
-    def __init__(self):
+    def __init__(self, supported_wikis: List[SupportedWikiConfig]):
         """Connect to Wikidot."""
         self._session = requests.sessions.Session()
+        self.supported_wikis = supported_wikis
+        # Always add the 'base' wiki even if it's not configured
+        self.supported_wikis.append(
+            {"id": "www", "name": "Wikidot", "secure": 1}
+        )
 
     def post(self, url, **kwargs):
         """Make a POST request."""

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -34,12 +34,14 @@ class Connection:
 
     def module(self, wiki: str, module_name: str, **kwargs) -> WikidotResponse:
         """Call a Wikidot module."""
-        token7 = self._session.cookies.get("wikidot_token7")
+        token7 = self._session.cookies.get("wikidot_token7", "7777777")
         response = self.post(
             f"http://{wiki}.wikidot.com/ajax-module-connector.php",
             data=dict(moduleName=module_name, wikidot_token7=token7, **kwargs),
+            cookies={"wikidot_token7": token7},
         ).json()
         if response["status"] != "ok":
+            print(response)
             raise RuntimeError(response.get("message") or response["status"])
         return response
 


### PR DESCRIPTION
The scope of this PR is to have the thing be able to send Wikidot messages via PM. Sending messages via email is out of scope.

While I'm here:

- [x] For HTTPS-only wikis, RSS requests may come from HTTP, but ajax requests must come from HTTPS. Whenever I make an ajax request I must be sure to use that wiki's HTTP/S setting.