### PR TITLE
Send messages via email

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ poetry install
 ## Authentication
 
 notifier requires authentication in order to access its Wikidot account and
-its gmail account.
+its gmail account. [keyring](https://github.com/jaraco/keyring) is used for
+securely storing passwords.
+
+You may wish to set up keyring's backend yourself. notifier comes with
+[keyrings.cryptfile](https://pypi.org/project/keyrings.cryptfile/)
+installed by default.
 
 To set the authentication, open a Python shell:
 
@@ -40,6 +45,9 @@ import keyring
 keyring.set_password("yagmail", GMAIL_USERNAME, GMAIL_PASSWORD)
 keyring.set_password("wikidot", WIKIDOT_USERNAME, WIKIDOT_PASSWORD)
 ```
+
+You may be required to set a keyring password. Make sure you keep a record
+of it.
 
 The usernames must be the same as those defined in the config file.
 

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ config_wiki = "notifications"
 user_config_category = "notify"
 wiki_config_category = "wiki"
 overrides_url = "https://notifications.wdfiles.com/local--code/overrides/1"
-gmail_username = "wikidotnotifier"
+gmail_username = "wikidotnotifier@gmail.com"
 
 [notifier.path]
 # Paths:

--- a/config.toml
+++ b/config.toml
@@ -4,6 +4,7 @@ config_wiki = "notifications"
 user_config_category = "notify"
 wiki_config_category = "wiki"
 overrides_url = "https://notifications.wdfiles.com/local--code/overrides/1"
+gmail_username = "wikidotnotifier"
 
 [notifier.path]
 # Paths:

--- a/notifier/__main__.py
+++ b/notifier/__main__.py
@@ -30,7 +30,8 @@ def check_authentication(config: LocalConfig) -> None:
     """Verifies that the Wikidot and gmail passwords have been provided."""
     if not keyring.get_password("wikidot", config["wikidot_username"]):
         raise ValueError("Wikidot account password is not configured")
-    # TODO gmail password
+    if not keyring.get_password("yagmail", config["gmail_username"]):
+        raise ValueError("gmail account password is not configured")
 
 
 if __name__ == "__main__":

--- a/notifier/config/tool.py
+++ b/notifier/config/tool.py
@@ -46,6 +46,7 @@ def read_local_config(config_path: str) -> LocalConfig:
         assert_key(config, "user_config_category", str)
         assert_key(config, "wiki_config_category", str)
         assert_key(config, "overrides_url", str)
+        assert_key(config, "gmail_username", str)
         assert_key(config, "path", dict)
         assert_key(config["path"], "lang", str)
         config["path"]["lang"] = replace_path_alias(config["path"]["lang"])

--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -119,15 +119,6 @@ class BaseDatabaseDriver(ABC):
         """
 
     @abstractmethod
-    def check_would_email(self, frequencies: List[str]) -> bool:
-        """Checks if there is at least one user who is subscribed to one of
-        the provided frequency channels who has opted to recieve
-        notifications via email.
-
-        :param frequencies: The list of frequency channel names.
-        """
-
-    @abstractmethod
     def store_manual_sub(
         self, user_id: str, subscription: Subscription
     ) -> None:

--- a/notifier/database/drivers/sqlite.py
+++ b/notifier/database/drivers/sqlite.py
@@ -141,16 +141,6 @@ class SqliteDriver(DatabaseWithSqlFileCache, BaseDatabaseDriver):
                 self.store_manual_sub(user_config["user_id"], subscription)
         self.conn.commit()
 
-    def check_would_email(self, frequencies: List[str]) -> bool:
-        return any(
-            bool(
-                self.execute_named(
-                    "check_would_email", {"frequency": frequency}
-                ).fetchone()[0]
-            )
-            for frequency in frequencies
-        )
-
     def store_manual_sub(
         self, user_id: str, subscription: Subscription
     ) -> None:

--- a/notifier/database/queries/check_would_email.sql
+++ b/notifier/database/queries/check_would_email.sql
@@ -1,9 +1,0 @@
-SELECT EXISTS (
-  SELECT
-    1
-  FROM
-    user_config
-  WHERE
-    frequency = :frequency
-    AND delivery = "email"
-)

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -23,7 +23,6 @@ from emoji import emojize
 from notifier.formatter import convert_syntax_to_html
 from notifier.types import (
     CachedUserConfig,
-    DeliveryMethod,
     IsSecure,
     NewPostsInfo,
     PostInfo,
@@ -59,23 +58,19 @@ class Digester:
         self.lexicon = process_long_strings(self.lexicon)
 
     @lru_cache(maxsize=None)
-    def make_lexicon(self, lang: str, method: DeliveryMethod):
-        """Constructs a subset of the full lexicon for a given language and
-        delivery method.
+    def make_lexicon(self, lang: str):
+        """Constructs a subset of the full lexicon for a given language.
 
-        These lexicons are cached per language and method, which will be
-        necessarily cleared on construction of a new Digester.
+        These lexicons are cached per language, which will be necessarily
+        cleared on construction of a new Digester.
         """
         # Later keys in the lexicon will override previous ones - e.g. for
         # a non-en language, its keys should override all of en's, but in
         # case they don't, en's are used as a fallback.
         lexicon = {
             **self.lexicon.get("base", {}),
-            **self.lexicon.get("base", {}).get(method, {}),
             **self.lexicon.get("en", {}),
-            **self.lexicon.get("en", {}).get(method, {}),
             **self.lexicon.get(lang, {}),
-            **self.lexicon.get(lang, {}).get(method, {}),
         }
         return lexicon
 
@@ -88,7 +83,7 @@ class Digester:
         digest body.
         """
         # Make the lexicon for this user's settings
-        lexicon = self.make_lexicon(user["language"], user["delivery"])
+        lexicon = self.make_lexicon(user["language"])
         # Get some stats for the message
         # TODO Subscription statistics
         sub_count = None

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -20,7 +20,7 @@ from typing import (
 import tomlkit
 from emoji import emojize
 
-from notifier.formatter import convert_syntax_to_html
+from notifier.formatter import convert_syntax
 from notifier.types import (
     CachedUserConfig,
     IsSecure,
@@ -120,8 +120,7 @@ class Digester:
             outro=outro,
         )
         body = finalise_digest(body)
-        if user["delivery"] == "email":
-            body = convert_syntax_to_html(body)
+        body = convert_syntax(body, user["delivery"])
         return total_notification_count, subject, body
 
 

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -20,6 +20,7 @@ from typing import (
 import tomlkit
 from emoji import emojize
 
+from notifier.formatter import convert_syntax_to_html
 from notifier.types import (
     CachedUserConfig,
     DeliveryMethod,
@@ -78,7 +79,7 @@ class Digester:
         }
         return lexicon
 
-    def for_user(  # pylint: disable=too-many-locals
+    def for_user(
         self, user: CachedUserConfig, posts: NewPostsInfo
     ) -> Tuple[int, str, str]:
         """Compile a notification digest for a user.
@@ -124,6 +125,8 @@ class Digester:
             outro=outro,
         )
         body = finalise_digest(body)
+        if user["delivery"] == "email":
+            body = convert_syntax_to_html(body)
         return total_notification_count, subject, body
 
 

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -76,7 +76,7 @@ class Digester:
 
     def for_user(
         self, user: CachedUserConfig, posts: NewPostsInfo
-    ) -> Tuple[int, str, str]:
+    ) -> Tuple[str, str]:
         """Compile a notification digest for a user.
 
         Returns a tuple of notification count, message subject and the
@@ -90,7 +90,7 @@ class Digester:
         manual_sub_count = None
         auto_thread_sub_count = None
         auto_post_sub_count = None
-        total_notification_count = 0
+        total_notification_count = None
         # Construct the message
         subject = lexicon["subject"].format(
             post_count=total_notification_count
@@ -121,7 +121,7 @@ class Digester:
         )
         body = finalise_digest(body)
         body = convert_syntax(body, user["delivery"])
-        return total_notification_count, subject, body
+        return subject, body
 
 
 def make_wikis_digest(new_posts: NewPostsInfo, lexicon: dict) -> List[str]:

--- a/notifier/emailer.py
+++ b/notifier/emailer.py
@@ -9,4 +9,4 @@ class Emailer:  # pylint: disable=too-few-public-methods
 
     def send(self, address: str, subject: str, body: str) -> None:
         """Send an email to an address."""
-        self.yag.send(address, subject, body)
+        self.yag.send(address, subject, body, prettify_html=False)

--- a/notifier/emailer.py
+++ b/notifier/emailer.py
@@ -1,13 +1,11 @@
 import yagmail
 
-from notifier.types import LocalConfig
-
 
 class Emailer:  # pylint: disable=too-few-public-methods
     """Responsible for sending emails."""
 
-    def __init__(self, config: LocalConfig):
-        self.yag = yagmail.SMTP(config["gmail_username"])
+    def __init__(self, gmail_username: str):
+        self.yag = yagmail.SMTP(gmail_username)
 
     def send(self, address: str, subject: str, body: str) -> None:
         """Send an email to an address."""

--- a/notifier/emailer.py
+++ b/notifier/emailer.py
@@ -1,0 +1,14 @@
+import yagmail
+
+from notifier.types import LocalConfig
+
+
+class Emailer:  # pylint: disable=too-few-public-methods
+    """Responsible for sending emails."""
+
+    def __init__(self, config: LocalConfig):
+        self.yag = yagmail.SMTP(config["gmail_username"])
+
+    def send(self, address: str, subject: str, body: str) -> None:
+        """Send an email to an address."""
+        self.yag.send(address, subject, body)

--- a/notifier/formatter.py
+++ b/notifier/formatter.py
@@ -1,0 +1,51 @@
+import re
+import time
+from re import Match, Pattern
+from typing import Callable, List, Tuple, Union, cast
+
+replacements: List[
+    Union[Tuple[str, str], Tuple[Pattern, Union[str, Callable[[Match], str]]]]
+] = [
+    # Alignment
+    ("[[=]]", """<div style="text-align: center">"""),
+    ("[[/=]]", "</div>"),
+    # Wikidot user elements
+    (re.compile(r"<\*?user (.*?)>"), "$1"),
+    # Wikidot date elements
+    (
+        re.compile(r"\[\[date ([0-9]+) format=\"([^|]*).*?\"\]\]"),
+        lambda match: time.strftime(match[2], time.gmtime(int(match[1]))),
+    ),
+    # Inline formatting
+    (re.compile(r"//(.+?)//"), "<i>$1</i>"),
+    (re.compile(r"\*\*(.+?)\*\*"), "<b>$1</b>"),
+    (re.compile(r"##(\S+)\|(.+?)##"), """<span style="color: $1">$2</span>"""),
+    # Remaining misc elements like ul/li
+    ("[[", "<"),
+    ("]]", ">"),
+    # Links
+    (re.compile(r"\[(\S+) (.+?)\]"), """<a href="$1">$2</a>"""),
+    # Headings
+    (
+        re.compile(r"^(\++) (.+)$"),
+        lambda match: "<h{0}>{1}</h{0}>".format(len(match[1]), match[2]),
+    ),
+    # Dashes
+    ("--", "&mdash;"),
+    # Bullets
+    (re.compile(r"^\* (.+)$"), "<ul><li>$1</li></ul>"),
+]
+
+
+def convert_syntax_to_html(digest: str) -> str:
+    """Converts Wikidot syntax roughly to HTML.
+
+    Supports only a tiny subset of full Wikidot syntax and only does it
+    approximately. Good enough for notifications.
+    """
+    for find, replace in replacements:
+        if isinstance(find, str):
+            digest = digest.replace(find, cast(str, replace))
+        else:
+            digest = find.sub(replace, digest)
+    return digest

--- a/notifier/formatter.py
+++ b/notifier/formatter.py
@@ -3,47 +3,65 @@ import time
 from re import Match, Pattern
 from typing import Callable, List, Tuple, Union, cast
 
-replacements: List[
+from notifier.types import DeliveryMethod
+
+
+def r(regex: str) -> Pattern:
+    """Compiles a regular expression."""
+    return re.compile(regex, flags=re.MULTILINE)
+
+
+ReplacementList = List[
     Union[Tuple[str, str], Tuple[Pattern, Union[str, Callable[[Match], str]]]]
-] = [
+]
+
+replacements_to_html: ReplacementList = [
     # Alignment
     ("[[=]]", """<div style="text-align: center">"""),
     ("[[/=]]", "</div>"),
     # Wikidot user elements
-    (re.compile(r"<\*?user (.*?)>"), "$1"),
+    (r(r"\[\[\*?user (.*?)\]\]"), r"\1"),
     # Wikidot date elements
     (
-        re.compile(r"\[\[date ([0-9]+) format=\"([^|]*).*?\"\]\]"),
+        r(r"\[\[date ([0-9]+) format=\"([^|]*).*?\"\]\]"),
         lambda match: time.strftime(match[2], time.gmtime(int(match[1]))),
     ),
     # Inline formatting
-    (re.compile(r"//(.+?)//"), "<i>$1</i>"),
-    (re.compile(r"\*\*(.+?)\*\*"), "<b>$1</b>"),
-    (re.compile(r"##(\S+)\|(.+?)##"), """<span style="color: $1">$2</span>"""),
+    (r(r"//(.+?)//"), r"<i>\1</i>"),
+    (r(r"\*\*(.+?)\*\*"), r"<b>\1</b>"),
+    (
+        r(r"##(\S+)\|(.+?)##"),
+        r"""<span style="color: \1">\2</span>""",
+    ),
     # Remaining misc elements like ul/li
     ("[[", "<"),
     ("]]", ">"),
     # Links
-    (re.compile(r"\[(\S+) (.+?)\]"), """<a href="$1">$2</a>"""),
+    (r(r"\[(\S+) (.+?)\]"), r"""<a href="\1">\2</a>"""),
     # Headings
     (
-        re.compile(r"^(\++) (.+)$"),
+        r(r"^(\++) (.+)$"),
         lambda match: "<h{0}>{1}</h{0}>".format(len(match[1]), match[2]),
     ),
     # Dashes
     ("--", "&mdash;"),
     # Bullets
-    (re.compile(r"^\* (.+)$"), "<ul><li>$1</li></ul>"),
+    (r(r"^\* (.+)$"), r"<ul><li>\1</li></ul>"),
+    # Remove unnecessary breaks effected by Wikidot's lax spacing
+    ("\n", ""),
 ]
 
+replacements_to_wikitext: ReplacementList = [("<br>", "")]
 
-def convert_syntax_to_html(digest: str) -> str:
-    """Converts Wikidot syntax roughly to HTML.
 
-    Supports only a tiny subset of full Wikidot syntax and only does it
-    approximately. Good enough for notifications.
+def convert_syntax(digest: str, method: DeliveryMethod) -> str:
+    """Converts the pseudo-syntax used for digest templates to either full
+    Wikitext or full HTML based on the intended delivery method.
     """
-    for find, replace in replacements:
+    for find, replace in {
+        "email": replacements_to_html,
+        "pm": replacements_to_wikitext,
+    }[method]:
         if isinstance(find, str):
             digest = digest.replace(find, cast(str, replace))
         else:

--- a/notifier/lang.toml
+++ b/notifier/lang.toml
@@ -11,8 +11,6 @@ body = """
 
 {outro}
 """
-
-[base.pm]
 wiki = """
 ++ {wiki_name}
 

--- a/notifier/lang.toml
+++ b/notifier/lang.toml
@@ -52,7 +52,7 @@ posts_section = """
 post = """
 [[li]]
 **[{post_url} {post_title}]** -- [[*user {post_author}]] -- {date}
-
+<br>
 **|** ##grey|//{snippet}//##
 [[/li]]
 """

--- a/notifier/tasks.py
+++ b/notifier/tasks.py
@@ -45,6 +45,15 @@ def notify_channel(  # pylint: disable=too-many-arguments
             user["user_id"],
             (user["last_notified_timestamp"], current_timestamp),
         )
+        post_count = len(posts["thread_posts"]) + len(posts["post_replies"])
+        print(
+            "[{}] Notifying {} about {} posts via {}".format(
+                channel, user["username"], post_count, user["delivery"]
+            )
+        )
+        if post_count == 0:
+            # Nothing to notify this user about
+            continue
         # Extract the 'last notification time' that will be recorded -
         # it is the timestamp of the most recent post this user is
         # being notified about
@@ -56,10 +65,7 @@ def notify_channel(  # pylint: disable=too-many-arguments
             )
         )
         # Compile the digest
-        count, subject, body = digester.for_user(user, posts)
-        if count == 0:
-            # Nothing to notify the user about
-            continue
+        subject, body = digester.for_user(user, posts)
         # Send the digests via PM to PM-subscribed users
         if user["delivery"] == "pm":
             connection.send_message(user["user_id"], subject, body)
@@ -86,6 +92,7 @@ def notify_channel(  # pylint: disable=too-many-arguments
         database.store_user_last_notified(
             user["user_id"], last_notified_timestamp
         )
+    print(f"Notified {len(user_configs)} users in {channel} channel")
 
 
 def notify_active_channels(

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -25,6 +25,7 @@ class LocalConfig(TypedDict):
     user_config_category: str
     wiki_config_category: str
     overrides_url: str
+    gmail_username: str
     path: LocalConfigPaths
 
 

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -4,7 +4,11 @@ import requests
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
-from notifier.parsethread import parse_thread_meta, parse_thread_page
+from notifier.parsethread import (
+    get_user_from_nametag,
+    parse_thread_meta,
+    parse_thread_page,
+)
 from notifier.types import (
     EmailAddresses,
     LocalConfig,
@@ -255,4 +259,33 @@ class Connection:
 
         Connection needs to be logged in.
         """
-        # TODO
+        contacts = BeautifulSoup(
+            self.module("www", "dashboard/messages/DMContactsModule")["body"],
+            "html.parser",
+        )
+        # Back contacts are stored in optional table.contact-list-table
+        # which immediately follows h2 (there is an optional one
+        # immediately following a h1 which is the regular contacts)
+        back_contacts_heading = cast(Union[Tag, None], contacts.find("h2"))
+        if back_contacts_heading is None:
+            # The heading does not appear if there are no back contacts
+            return {}
+        back_contacts_table = cast(
+            Union[Tag, None],
+            back_contacts_heading.find_next_sibling(
+                class_="contact-list-table"
+            ),
+        )
+        if back_contacts_table is None:
+            # If there is a heading there should also be a contacts table,
+            # but can't hurt to be sure
+            return {}
+        addresses = {}
+        for row in cast(Iterable[Tag], back_contacts_table.find_all("tr")):
+            nametag_cell, address_cell = cast(Iterator[Tag], row.children)
+            _, username = get_user_from_nametag(nametag_cell.contents[0])
+            if username is None:
+                continue
+            address = address_cell.get_text()
+            addresses[username] = address
+        return addresses

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -282,10 +282,14 @@ class Connection:
             return {}
         addresses = {}
         for row in cast(Iterable[Tag], back_contacts_table.find_all("tr")):
-            nametag_cell, address_cell = cast(Iterator[Tag], row.children)
-            _, username = get_user_from_nametag(nametag_cell.contents[0])
+            nametag_cell, address_cell = cast(
+                Iterable[Tag], row.find_all("td")
+            )
+            _, username = get_user_from_nametag(
+                cast(Tag, nametag_cell.find("span"))
+            )
             if username is None:
                 continue
-            address = address_cell.get_text()
-            addresses[username] = address
+            address = address_cell.get_text().strip()
+            addresses[username.strip()] = address
         return addresses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ feedparser = "^6.0.8"
 emoji = "^1.4.2"
 yagmail = {extras = ["all"], version = "^0.14.256"}
 keyring = "^23.1.0"
+SecretStorage = "^3.3.1"
+"keyrings.cryptfile" = "^1.3.8"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ tomlkit = "^0.7.2"
 pycron = "^3.0.0"
 feedparser = "^6.0.8"
 emoji = "^1.4.2"
+yagmail = {extras = ["all"], version = "^0.14.256"}
 keyring = "^23.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -103,9 +103,7 @@ def test_fake_digest():
             if post_timestamp >= fake_user["last_notified_timestamp"]
         ],
     }
-    lexicon = digester.make_lexicon(
-        fake_user["language"], fake_user["delivery"]
-    )
+    lexicon = digester.make_lexicon(fake_user["language"])
     digest = "\n".join(make_wikis_digest(fake_posts, lexicon))
     print(digest)
     print(digest[:25].replace("\n", "\\n"))

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -6,6 +6,7 @@ from notifier.digest import (
     pluralise,
     process_long_strings,
 )
+from notifier.formatter import convert_syntax
 from notifier.types import CachedUserConfig, NewPostsInfo
 
 
@@ -116,3 +117,4 @@ def test_fake_digest():
     assert digest.count(lexicon["post_replies_opener"]) == 4
     assert digest.count("Contents...") == 6
     assert digest.count("Response...") == 8
+    print(convert_syntax(digest, "email"))


### PR DESCRIPTION
For users for whom receiving Wikidot notifications is untenable (i.e. site administrators with lots of application notifications), emails are a useful alternative.

- [x] Get user email addresses from back-contacts without storing them
- [x] Set up email backend (gmail account or something?)
- [x] Make the digest format method-agnostic (#6)
- [x] Send emails
- [x] Only check for contacts if there is going to be at least one digest (with >0 notifications) send via email