### PR TITLE
Formatting for both PMs and emails

### DIFF
--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -20,6 +20,7 @@ from typing import (
 import tomlkit
 from emoji import emojize
 
+from notifier.formatter import convert_syntax_to_html
 from notifier.types import (
     CachedUserConfig,
     DeliveryMethod,
@@ -78,7 +79,7 @@ class Digester:
         }
         return lexicon
 
-    def for_user(  # pylint: disable=too-many-locals
+    def for_user(
         self, user: CachedUserConfig, posts: NewPostsInfo
     ) -> Tuple[int, str, str]:
         """Compile a notification digest for a user.
@@ -124,6 +125,8 @@ class Digester:
             outro=outro,
         )
         body = finalise_digest(body)
+        if user["delivery"] == "email":
+            body = convert_syntax_to_html(body)
         return total_notification_count, subject, body
 
 

--- a/notifier/formatter.py
+++ b/notifier/formatter.py
@@ -1,0 +1,51 @@
+import re
+import time
+from re import Match, Pattern
+from typing import Callable, List, Tuple, Union, cast
+
+replacements: List[
+    Union[Tuple[str, str], Tuple[Pattern, Union[str, Callable[[Match], str]]]]
+] = [
+    # Alignment
+    ("[[=]]", """<div style="text-align: center">"""),
+    ("[[/=]]", "</div>"),
+    # Wikidot user elements
+    (re.compile(r"<\*?user (.*?)>"), "$1"),
+    # Wikidot date elements
+    (
+        re.compile(r"\[\[date ([0-9]+) format=\"([^|]*).*?\"\]\]"),
+        lambda match: time.strftime(match[2], time.gmtime(int(match[1]))),
+    ),
+    # Inline formatting
+    (re.compile(r"//(.+?)//"), "<i>$1</i>"),
+    (re.compile(r"\*\*(.+?)\*\*"), "<b>$1</b>"),
+    (re.compile(r"##(\S+)\|(.+?)##"), """<span style="color: $1">$2</span>"""),
+    # Remaining misc elements like ul/li
+    ("[[", "<"),
+    ("]]", ">"),
+    # Links
+    (re.compile(r"\[(\S+) (.+?)\]"), """<a href="$1">$2</a>"""),
+    # Headings
+    (
+        re.compile(r"^(\++) (.+)$"),
+        lambda match: "<h{0}>{1}</h{0}>".format(len(match[1]), match[2]),
+    ),
+    # Dashes
+    ("--", "&mdash;"),
+    # Bullets
+    (re.compile(r"^\* (.+)$"), "<ul><li>$1</li></ul>"),
+]
+
+
+def convert_syntax_to_html(digest: str) -> str:
+    """Converts Wikidot syntax roughly to HTML.
+
+    Supports only a tiny subset of full Wikidot syntax and only does it
+    approximately. Good enough for notifications.
+    """
+    for find, replace in replacements:
+        if isinstance(find, str):
+            digest = digest.replace(find, cast(str, replace))
+        else:
+            digest = find.sub(replace, digest)
+    return digest

--- a/notifier/lang.toml
+++ b/notifier/lang.toml
@@ -11,8 +11,6 @@ body = """
 
 {outro}
 """
-
-[base.pm]
 wiki = """
 ++ {wiki_name}
 


### PR DESCRIPTION
I currently have formatting set up for PMs in Wikidot syntax. But I need emails as well.

I intended for the parts of the formatting file that have languages to be free of formatting, however, that's not the case. So it would be ideal to have some syntax that's neither Wikidot syntax nor HTML that can be converted to either. It doesn't need to be complicated, because I'm only using a tiny subset of either language. I can always add to it if other languages need more features.