### PR TITLE
Run tasks before and after infrequent channels

### DIFF
--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -98,6 +98,11 @@ class BaseDatabaseDriver(ABC):
         in notifications."""
 
     @abstractmethod
+    def mark_post_as_deleted(self, post_id: str) -> None:
+        """Marks a post as deleted, preventing it from appearing in
+        notifications. Also mark its children as deleted, recursively."""
+
+    @abstractmethod
     def get_new_posts_for_user(
         self, user_id: str, timestamp_range: Tuple[int, int]
     ) -> NewPostsInfo:

--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -158,7 +158,7 @@ class BaseDatabaseDriver(ABC):
     def store_thread(
         self,
         wiki_id: str,
-        category: Tuple[str, str],
+        category: Tuple[Optional[str], Optional[str]],
         thread: Tuple[str, str, Optional[str], int],
     ) -> None:
         """Store a thread. Doesn't matter if the thread or category is

--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -93,6 +93,11 @@ class BaseDatabaseDriver(ABC):
         present in the cache."""
 
     @abstractmethod
+    def mark_thread_as_deleted(self, thread_id: str) -> None:
+        """Marks a thread as deleted, preventing its posts from appearing
+        in notifications."""
+
+    @abstractmethod
     def get_new_posts_for_user(
         self, user_id: str, timestamp_range: Tuple[int, int]
     ) -> NewPostsInfo:

--- a/notifier/database/drivers/sqlite.py
+++ b/notifier/database/drivers/sqlite.py
@@ -88,6 +88,9 @@ class SqliteDriver(DatabaseWithSqlFileCache, BaseDatabaseDriver):
             )
         ]
 
+    def mark_thread_as_deleted(self, thread_id: str) -> None:
+        self.execute_named("mark_thread_as_deleted", {"id": thread_id})
+
     def get_new_posts_for_user(
         self, user_id: str, timestamp_range: Tuple[int, int]
     ) -> NewPostsInfo:

--- a/notifier/database/drivers/sqlite.py
+++ b/notifier/database/drivers/sqlite.py
@@ -210,14 +210,15 @@ class SqliteDriver(DatabaseWithSqlFileCache, BaseDatabaseDriver):
     def store_thread(
         self,
         wiki_id: str,
-        category: Tuple[str, str],
+        category: Tuple[Optional[str], Optional[str]],
         thread: Tuple[str, str, Optional[str], int],
     ) -> None:
         thread_id, thread_title, creator_username, created_timestamp = thread
         category_id, category_name = category
-        self.execute_named(
-            "store_category", {"id": category_id, "name": category_name}
-        )
+        if category_id is not None and category_name is not None:
+            self.execute_named(
+                "store_category", {"id": category_id, "name": category_name}
+            )
         self.execute_named(
             "store_thread",
             {

--- a/notifier/database/drivers/sqlite.py
+++ b/notifier/database/drivers/sqlite.py
@@ -91,6 +91,14 @@ class SqliteDriver(DatabaseWithSqlFileCache, BaseDatabaseDriver):
     def mark_thread_as_deleted(self, thread_id: str) -> None:
         self.execute_named("mark_thread_as_deleted", {"id": thread_id})
 
+    def mark_post_as_deleted(self, post_id: str) -> None:
+        self.execute_named("mark_post_as_deleted", {"id": post_id})
+        # Find any children of this post and delete them, too
+        for child in self.execute_named(
+            "get_post_children", {"id": post_id}
+        ).fetchall():
+            self.mark_post_as_deleted(child["id"])
+
     def get_new_posts_for_user(
         self, user_id: str, timestamp_range: Tuple[int, int]
     ) -> NewPostsInfo:

--- a/notifier/database/queries/create_tables.script.sql
+++ b/notifier/database/queries/create_tables.script.sql
@@ -41,7 +41,8 @@ CREATE TABLE IF NOT EXISTS thread (
   wiki_id TEXT NOT NULL,
   category_id TEXT,
   creator_username TEXT,
-  created_timestamp INTEGER NOT NULL
+  created_timestamp INTEGER NOT NULL,
+  is_deleted INTEGER NOT NULL CHECK (is_deleted IN (0, 1)) DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS post (

--- a/notifier/database/queries/create_tables.script.sql
+++ b/notifier/database/queries/create_tables.script.sql
@@ -53,5 +53,6 @@ CREATE TABLE IF NOT EXISTS post (
   title TEXT NOT NULL,
   snippet TEXT NOT NULL,
   user_id TEXT NOT NULL,
-  username TEXT NOT NULL
+  username TEXT NOT NULL,
+  is_deleted INTEGER NOT NULL CHECK (is_deleted IN (0, 1)) DEFAULT 0
 );

--- a/notifier/database/queries/get_post_children.sql
+++ b/notifier/database/queries/get_post_children.sql
@@ -1,0 +1,6 @@
+SELECT
+  id
+FROM
+  post
+WHERE
+  parent_post_id = :id

--- a/notifier/database/queries/get_posts_in_subscribed_threads.sql
+++ b/notifier/database/queries/get_posts_in_subscribed_threads.sql
@@ -47,8 +47,11 @@ WHERE
     )
   )
 
-  -- Select only posts in non-deleted threads
+  -- Remove posts in deleted threads
   AND thread.is_deleted = 0
+
+  -- Remove deleted posts
+  AND post.is_deleted = 0
 
   -- Remove posts in threads unsubscribed from
   AND NOT EXISTS (

--- a/notifier/database/queries/get_posts_in_subscribed_threads.sql
+++ b/notifier/database/queries/get_posts_in_subscribed_threads.sql
@@ -47,6 +47,9 @@ WHERE
     )
   )
 
+  -- Select only posts in non-deleted threads
+  AND thread.is_deleted = 0
+
   -- Remove posts in threads unsubscribed from
   AND NOT EXISTS (
     SELECT NULL FROM

--- a/notifier/database/queries/get_replies_to_subscribed_posts.sql
+++ b/notifier/database/queries/get_replies_to_subscribed_posts.sql
@@ -44,6 +44,9 @@ WHERE
     OR parent_post.user_id = :user_id
   )
 
+  -- Select only posts in non-deleted threads
+  AND thread.is_deleted = 0
+
   -- Remove replies to posts unsubscribed from
   AND NOT EXISTS (
     SELECT NULL FROM

--- a/notifier/database/queries/get_replies_to_subscribed_posts.sql
+++ b/notifier/database/queries/get_replies_to_subscribed_posts.sql
@@ -47,6 +47,9 @@ WHERE
   -- Select only posts in non-deleted threads
   AND thread.is_deleted = 0
 
+  -- Remove deleted posts
+  AND post.is_deleted = 0
+
   -- Remove replies to posts unsubscribed from
   AND NOT EXISTS (
     SELECT NULL FROM

--- a/notifier/database/queries/mark_thread_as_deleted.sql
+++ b/notifier/database/queries/mark_thread_as_deleted.sql
@@ -1,0 +1,6 @@
+UPDATE
+  thread
+SET
+  is_deleted = 1
+WHERE
+  id = :id

--- a/notifier/deletions.py
+++ b/notifier/deletions.py
@@ -1,0 +1,67 @@
+import time
+from typing import List, Set, Tuple
+
+from notifier.database.drivers.base import BaseDatabaseDriver
+from notifier.wikiconnection import Connection, ThreadNotExists
+
+
+def clear_deleted_threads(
+    frequency: str, database: BaseDatabaseDriver, connection: Connection
+):
+    """Remove deleted threads from the database.
+
+    For each thread that a user on the given channel would soon be
+    notified about, check that it still exists. If it does not, flag it as
+    deleted in the cache, preventing it from emitting any notifications.
+
+    If no users were about to be notified about a thread, there is no point
+    bothering to look up whether it still exists or not.
+    """
+    print(f"Clearing deleted threads from the {frequency} channel")
+    now = int(time.time())
+    users = database.get_user_configs(frequency)
+    threads: Set[Tuple[str, str, str]] = set()
+    for user in users:
+        posts = database.get_new_posts_for_user(
+            user["user_id"], (user["last_notified_timestamp"], now)
+        )
+        for post in posts["thread_posts"]:
+            threads.add((post["wiki_id"], post["thread_id"], post["id"]))
+        for reply in posts["post_replies"]:
+            threads.add((reply["wiki_id"], reply["thread_id"], reply["id"]))
+    print(f"Found {len(threads)} threads to check")
+    deleted_threads: List[Tuple[str, str]] = []
+    deleted_posts: List[Tuple[str, str, str]] = []
+    for wiki_id, thread_id, post_id in threads:
+        # Construct the iterator for thread pages
+        thread_pages = connection.thread(wiki_id, thread_id, post_id)
+        try:
+            # The first iteration is a special case and returns information
+            # about the thread; it will always succeed if the thread exists
+            next(thread_pages)
+        except ThreadNotExists:
+            database.mark_thread_as_deleted(thread_id)
+            deleted_threads.append((wiki_id, thread_id))
+            continue
+        try:
+            # Second iteration returns the first post from the targeted
+            # page; if there are no posts it means the targeted page
+            # doesn't exist and therefore neither does the targeted post
+            next(thread_pages)
+        except StopIteration:
+            database.mark_post_as_deleted(post_id)
+            deleted_posts.append((wiki_id, thread_id, post_id))
+            continue
+
+        # If the post does exist, record all post IDs seen in that page,
+        # which are known to exist and don't need to be checked
+        # TODO
+        # Actually I don't think this will work the way I've implemented
+        # thing because Connection.thread returns a generator of posts, not
+        # of pages - I guess I need to call the method it uses internally
+        # directly
+    print(f"Deleted {len(deleted_threads)} threads")
+    print(
+        f"Deleted {len(deleted_posts)} posts "
+        f"in {len(set(d[1] for d in deleted_posts))} threads"
+    )

--- a/notifier/deletions.py
+++ b/notifier/deletions.py
@@ -1,14 +1,20 @@
 import time
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, cast
 
 from notifier.database.drivers.base import BaseDatabaseDriver
+from notifier.types import RawPost
 from notifier.wikiconnection import Connection, ThreadNotExists
 
+# A strict thread ID contains the ID of its wiki
+StrictThreadId = Tuple[str, str]
+# A strict post ID contains the IDs of its wiki and thread
+StrictPostId = Tuple[str, str, str]
 
-def clear_deleted_threads(
+
+def clear_deleted_posts(
     frequency: str, database: BaseDatabaseDriver, connection: Connection
 ):
-    """Remove deleted threads from the database.
+    """Remove deleted posts from the database.
 
     For each thread that a user on the given channel would soon be
     notified about, check that it still exists. If it does not, flag it as
@@ -17,51 +23,83 @@ def clear_deleted_threads(
     If no users were about to be notified about a thread, there is no point
     bothering to look up whether it still exists or not.
     """
-    print(f"Clearing deleted threads from the {frequency} channel")
+    print(f"Clearing deleted posts from the {frequency} channel")
+    posts = find_posts_to_check(frequency, database)
+    print(
+        f"Found {len(posts)} posts to check"
+        f" in {len(set(post[1] for post in posts))} threads"
+    )
+    deleted_threads, deleted_posts = delete_posts(posts, database, connection)
+    print(
+        f"Deleted {len(deleted_threads)} threads"
+        f" in {len(set(d[0] for d in deleted_threads))} wikis"
+    )
+    print(
+        f"Deleted {len(deleted_posts)} posts"
+        f" in {len(set(d[1] for d in deleted_posts))} threads"
+        f" in {len(set(d[0] for d in deleted_posts))} wikis"
+    )
+
+
+def find_posts_to_check(
+    frequency: str, database: BaseDatabaseDriver
+) -> Set[StrictPostId]:
+    """For users on the given channel, find which threads and posts should
+    be checked for deletion."""
     now = int(time.time())
     users = database.get_user_configs(frequency)
-    threads: Set[Tuple[str, str, str]] = set()
+    posts_to_check: Set[StrictPostId] = set()
     for user in users:
         posts = database.get_new_posts_for_user(
             user["user_id"], (user["last_notified_timestamp"], now)
         )
         for post in posts["thread_posts"]:
-            threads.add((post["wiki_id"], post["thread_id"], post["id"]))
+            posts_to_check.add(
+                (post["wiki_id"], post["thread_id"], post["id"])
+            )
         for reply in posts["post_replies"]:
-            threads.add((reply["wiki_id"], reply["thread_id"], reply["id"]))
-    print(f"Found {len(threads)} threads to check")
-    deleted_threads: List[Tuple[str, str]] = []
-    deleted_posts: List[Tuple[str, str, str]] = []
-    for wiki_id, thread_id, post_id in threads:
-        # Construct the iterator for thread pages
-        thread_pages = connection.thread(wiki_id, thread_id, post_id)
+            posts_to_check.add(
+                (reply["wiki_id"], reply["thread_id"], reply["id"])
+            )
+    return posts_to_check
+
+
+def delete_posts(
+    posts: Set[StrictPostId],
+    database: BaseDatabaseDriver,
+    connection: Connection,
+) -> Tuple[Set[StrictThreadId], Set[StrictPostId]]:
+    """For each post, check if it exists. If it doesn't (or if the thread
+    doesn't), mark it as deleted in the database."""
+    deleted_threads: Set[StrictThreadId] = set()
+    deleted_posts: Set[StrictPostId] = set()
+    existing_posts: Set[str] = set()
+
+    for wiki_id, thread_id, post_id in posts:
+        if post_id in existing_posts:
+            continue
+
+        thread_info = connection.thread(wiki_id, thread_id, post_id)
+        # The first iteration is a special case and returns information
+        # about the thread; it will always succeed if the thread exists
         try:
-            # The first iteration is a special case and returns information
-            # about the thread; it will always succeed if the thread exists
-            next(thread_pages)
+            next(thread_info)
         except ThreadNotExists:
             database.mark_thread_as_deleted(thread_id)
-            deleted_threads.append((wiki_id, thread_id))
+            deleted_threads.add((wiki_id, thread_id))
             continue
-        try:
-            # Second iteration returns the first post from the targeted
-            # page; if there are no posts it means the targeted page
-            # doesn't exist and therefore neither does the targeted post
-            next(thread_pages)
-        except StopIteration:
+
+        # Subsequent iterations return posts from the targeted page; if
+        # there are no posts it means the targeted page doesn't exist and
+        # therefore neither does the targeted post
+        thread_posts = cast(List[RawPost], list(thread_info))
+        if len(thread_posts) == 0:
             database.mark_post_as_deleted(post_id)
-            deleted_posts.append((wiki_id, thread_id, post_id))
+            deleted_posts.add((wiki_id, thread_id, post_id))
             continue
 
         # If the post does exist, record all post IDs seen in that page,
-        # which are known to exist and don't need to be checked
-        # TODO
-        # Actually I don't think this will work the way I've implemented
-        # thing because Connection.thread returns a generator of posts, not
-        # of pages - I guess I need to call the method it uses internally
-        # directly
-    print(f"Deleted {len(deleted_threads)} threads")
-    print(
-        f"Deleted {len(deleted_posts)} posts "
-        f"in {len(set(d[1] for d in deleted_posts))} threads"
-    )
+        # which are known to exist so don't need to be checked later
+        existing_posts.update(post["id"] for post in thread_posts)
+
+    return deleted_threads, deleted_posts

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -3,7 +3,6 @@ import time
 from typing import List, Optional, cast
 
 import keyring
-import pycron
 
 from notifier.config.local import read_local_config
 from notifier.config.remote import get_global_config
@@ -12,6 +11,7 @@ from notifier.database.drivers.base import BaseDatabaseDriver
 from notifier.digest import Digester
 from notifier.emailer import Emailer
 from notifier.newposts import get_new_posts
+from notifier.timing import channel_is_now
 from notifier.types import (
     EmailAddresses,
     GlobalOverrideConfig,
@@ -45,7 +45,7 @@ def notify_active_channels(
     active_channels = [
         frequency
         for frequency, crontab in notification_channels.items()
-        if pycron.is_now(crontab)
+        if channel_is_now(crontab)
     ]
     # If there are no active channels, which shouldn't happen, there is
     # nothing to do

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -76,7 +76,7 @@ def parse_thread_page(thread_id: str, thread_page: Tag) -> List[RawPost]:
         if posted_timestamp is None:
             print(f"Couldn't read timestamp for {thread_id}/{post_id}")
             continue
-        post_title = cast(Tag, post.find(class_="title")).get_text()
+        post_title = cast(Tag, post.find(class_="title")).get_text().strip()
         post_snippet = make_post_snippet(post)
         raw_posts.append(
             {
@@ -95,7 +95,7 @@ def parse_thread_page(thread_id: str, thread_page: Tag) -> List[RawPost]:
 
 def make_post_snippet(post: Tag) -> str:
     """Truncate a post's text contents to elicit a snippet."""
-    contents = cast(Tag, post.find(class_="content")).get_text()
+    contents = cast(Tag, post.find(class_="content")).get_text().strip()
     if len(contents) >= 80:
         contents = contents[:75].strip() + "..."
     return contents

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -113,7 +113,7 @@ def get_post_parent_id(post_container: Tag) -> Optional[str]:
     # that container is the ID of the parent post
     parent_element = cast(Tag, post_container.parent)
     parent_post_id = None
-    if parent_element["class"] == "post-container":
+    if "post-container" in parent_element.get_attribute_list("class"):
         parent_container_id = parent_element.get_attribute_list("id")[0]
         parent_post_id = "post-" + parent_container_id.lstrip("fpc-")
     return parent_post_id

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -61,7 +61,7 @@ def parse_thread_page(thread_id: str, thread_page: Tag) -> List[RawPost]:
         parent_post_id = get_post_parent_id(post_container)
         # Move to the post itself, to avoid deep searches accidentally
         # hitting replies
-        post = cast(Tag, post_container.contents[0])
+        post = cast(Tag, post_container.find(class_="post"))
         post_id = post.get_attribute_list("id")[0]
         # The post author and timestamp are kept in a .info - jump here to
         # avoid accidentally picking up users and timestamps from the post

--- a/notifier/timing.py
+++ b/notifier/timing.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+
+import pycron
+
+
+def channel_is_now(crontab: str):
+    """Checks if the given notification channel should be activated right
+    now."""
+    return pycron.is_now(crontab)
+
+
+def channel_will_be_next(crontab: str):
+    """Checks if the given notification channel will be activated on the
+    next channel, in an hour."""
+    return pycron.is_now(crontab, dt=datetime.now() + timedelta(hours=1))
+
+
+def channel_was_previous(crontab: str):
+    """Checks if the given notification channel was activated on the
+    previous channel an hour ago (in theory)."""
+    return pycron.is_now(crontab, dt=datetime.now() - timedelta(hours=1))

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -27,6 +27,11 @@ listpages_div_wrap = f"""
 """
 
 
+class ThreadNotExists(Exception):
+    """Indicates that a thread does not exist, meaning (if it was known to
+    exist before) that it was deleted."""
+
+
 class Connection:
     """Connection to Wikidot facilitating communications with it."""
 
@@ -83,6 +88,8 @@ class Connection:
             data=dict(moduleName=module_name, wikidot_token7=token7, **kwargs),
             cookies={"wikidot_token7": token7},
         ).json()
+        if response["status"] == "no_thread":
+            raise ThreadNotExists
         if response["status"] != "ok":
             print(response)
             raise RuntimeError(response.get("message") or response["status"])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -44,7 +44,17 @@ def sample_database():
     )
     db.conn.executemany("INSERT INTO wiki VALUES (?, ?, ?)", sample_wikis)
     db.conn.executemany(
-        "INSERT INTO thread VALUES (?, ?, ?, ?, ?, ?)", sample_threads
+        """
+        INSERT INTO thread (
+            id,
+            title,
+            wiki_id,
+            category_id,
+            creator_username,
+            created_timestamp
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        sample_threads,
     )
     db.conn.executemany(
         "INSERT INTO post VALUES (?, ?, ?, ?, ?, ?, ?, ?)", sample_posts

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -136,3 +136,12 @@ def test_respect_ignored_thread(thread_posts):
 def test_new_threads(sample_database: BaseDatabaseDriver):
     """Test that the utility for checking if threads exists works."""
     assert sample_database.find_new_threads(["t-1", "t-2", "t-99"]) == ["t-99"]
+
+
+def test_deleted_thread(sample_database: BaseDatabaseDriver):
+    """Test that marking a thread as deleted works and that it then does
+    not appear in notifications."""
+    sample_database.mark_thread_as_deleted("t-1")
+    posts = sample_database.get_new_posts_for_user("1", (0, 100))
+    assert "t-1" not in [reply["thread_id"] for reply in posts["post_replies"]]
+    assert "t-1" not in [post["thread_id"] for post in posts["thread_posts"]]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -44,20 +44,11 @@ def sample_database():
     )
     db.conn.executemany("INSERT INTO wiki VALUES (?, ?, ?)", sample_wikis)
     db.conn.executemany(
-        """
-        INSERT INTO thread (
-            id,
-            title,
-            wiki_id,
-            category_id,
-            creator_username,
-            created_timestamp
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        """,
+        "INSERT INTO thread VALUES (?, ?, ?, ?, ?, ?, 0)",
         sample_threads,
     )
     db.conn.executemany(
-        "INSERT INTO post VALUES (?, ?, ?, ?, ?, ?, ?, ?)", sample_posts
+        "INSERT INTO post VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)", sample_posts
     )
     db.conn.commit()
     return db


### PR DESCRIPTION
There are four channels:

* hourly
* daily
* weekly
* monthly

Of those, I am categorising weekly and monthly as 'infrequent'.

After the channel immediately preceding an infrequent channel (i.e. the hourly channel that runs an hour before it), any built-up notifications for users on that infrequent channel should be checked to see if those threads still exist (maybe even check posts individually, as a bonus).

(It occurs to me that it's probably worthwhile to only run this on the weekly channel rather than both the weekly and monthly channel.)

After the channel immediately following an infrequent channel, infrequent users should be checked to ensure that on the prior channel, they were actually notified. If not, they should be re-notified.

## Base

- [x] Find a reliable way of determining the current channel's relationship to another channel (and, depending on the implementation, maybe use this method to determine which channels should be activated for a given channel)
- [x] Check that a) apscheduler starts tasks within one minute of the declared time **guaranteed**, b) that pycron always accurately assesses that time

## Before

- [x] On the frequent channel before an infrequent channel, check for deleted threads
- [x] Make the checker dependent on channel, and only delete posts relevant to users on that channel
- [x] Don't actually delete the threads in the cache - just set a flag
- [x] Don't notify users about posts that have that flag

## After

- [x] ~~On the frequent channel after an infrequent channel, check that subscribers of the infrequent channel were notified~~ See comment below

Although that being said... if the original notification procedure is done correctly, this would never be called. Is this a good idea? Is it worth the effort?