### PR TITLE
Granular database control

### DIFF
--- a/notifier/database/queries/store_post.sql
+++ b/notifier/database/queries/store_post.sql
@@ -1,4 +1,4 @@
-INSERT OR UPDATE INTO
+INSERT OR REPLACE INTO
   post
   (
     id,

--- a/notifier/database/queries/store_thread.sql
+++ b/notifier/database/queries/store_thread.sql
@@ -1,4 +1,4 @@
-INSERT OR UPDATE INTO
+INSERT OR REPLACE INTO
   thread
   (id, title, wiki_id, category_id, creator_username, created_timestamp)
 VALUES


### PR DESCRIPTION
SQLite runs in autocommit mode by default (which is temporarily turned off during an explicit transaction), but [Python's sqlite3 module](https://docs.python.org/3/library/sqlite3.html#sqlite3-controlling-transactions) does not - instead, it implicitly creates transactions around passed statements. It's sort of the same as what SQLite does in autocommit mode, except written in Python instead.

But there's a couple of places in notifier where I want to have control over that process. In particular in the following places:

https://github.com/croque-scp/notifier/blob/9d49216f2526eeaba8aea91858a981e68121cb31/notifier/database/drivers/sqlite.py#L69-L72

https://github.com/croque-scp/notifier/blob/9d49216f2526eeaba8aea91858a981e68121cb31/notifier/database/drivers/sqlite.py#L156-L160

https://github.com/croque-scp/notifier/blob/9d49216f2526eeaba8aea91858a981e68121cb31/notifier/database/drivers/sqlite.py#L205-L209

Basically anywhere that I'm deleting a whole bunch of stale data to replace it with new data.

If adding the new data fails for whatever reason, I want to be able to rollback to *before* I deleted the old data. Maybe Python's sqlite3 will do that automatically, but I don't trust it. I want to be able to do this myself, and I want to do it explicitly.

The three kinds of transaction are DEFERRED, IMMEDIATE and EXCLUSIVE. They are important when there are multiple clients accessing the same database; however, I only have one, so I don't need to care.