### PR TITLE
Manual timing control

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,26 @@ GRANT ALL PRIVILEGES ON `<name>_test`.* TO '<username>'@'<host>';
 
 ## Execution
 
-To start the notifier:
+To start the notifier service:
 
 ```shell
 poetry run python3 -m notifier path_to_config_file path_to_auth_file
 ```
 
-The standard config file is `config.toml`.
+The config file that my notifier instance uses is `config.toml`. A sample
+auth file with dummy secrets, used for CI tests, can be found at
+`.github/auth.ci.toml`.
 
-Note that the script will immediately ask for the keyring password, which
-must be entered in order for it to be able to work.
+The service will run continuously and activate an automatically-determined
+set of notification channels each hour.
+
+To activate a channel or multiple channels immediately and once only, add
+the `--execute-now` switch followed by any of `hourly`, `daily`, `weekly`
+and `monthly`.
+
+To activate an automatically-determined set of channels immediately and
+once only, add the `--execute-now` switch with no parameter. Note that this
+must be run during the first minute of an hour to match any channels.
 
 # Development
 

--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -1,0 +1,7 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s:%(lineno)s - %(levelname)s - %(message)s",
+    level="DEBUG",
+)

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -7,11 +7,7 @@ from apscheduler.triggers.cron import CronTrigger
 
 from notifier.config.local import read_local_auth, read_local_config
 from notifier.database.utils import resolve_driver_from_config
-from notifier.notify import (
-    notification_channels,
-    notify,
-    print_time_until_next,
-)
+from notifier.notify import notification_channels, notify
 from notifier.types import AuthConfig, LocalConfig
 
 logger = logging.getLogger(__name__)
@@ -40,8 +36,6 @@ def cli():
         CronTrigger.from_crontab(notification_channels["hourly"]),
         args=(config, auth, database),
     )
-
-    print_time_until_next()
 
     # Let's go
     scheduler.start()

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -6,7 +6,11 @@ from apscheduler.triggers.cron import CronTrigger
 
 from notifier.config.local import read_local_auth, read_local_config
 from notifier.database.utils import resolve_driver_from_config
-from notifier.notify import notification_channels, notify_active_channels
+from notifier.notify import (
+    notification_channels,
+    notify,
+    print_time_until_next,
+)
 from notifier.types import AuthConfig, LocalConfig
 
 
@@ -24,10 +28,12 @@ def cli():
 
     # Schedule the task
     scheduler.add_job(
-        notify_active_channels,
+        notify,
         CronTrigger.from_crontab(notification_channels["hourly"]),
         args=(config, auth, database),
     )
+
+    print_time_until_next()
 
     # Let's go
     scheduler.start()

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from typing import Tuple
 
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -12,6 +13,8 @@ from notifier.notify import (
     print_time_until_next,
 )
 from notifier.types import AuthConfig, LocalConfig
+
+logger = logging.getLogger(__name__)
 
 
 def cli():

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -27,7 +27,12 @@ def cli():
 
     # Database stores forum posts and caches subscriptions
     DatabaseDriver = resolve_driver_from_config(config["database"]["driver"])
-    database = DatabaseDriver(config["database"]["database_name"])
+    database = DatabaseDriver(
+        config["database"]["database_name"],
+        host=auth["mysql"]["host"],
+        username=auth["mysql"]["username"],
+        password=auth["mysql"]["password"],
+    )
 
     # Schedule the task
     scheduler.add_job(

--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -41,6 +41,11 @@ class BaseDatabaseDriver(ABC):
         set for."""
 
     @abstractmethod
+    def find_new_posts(self, post_ids: Iterable[str]) -> List[str]:
+        """From a list of post IDs, return those that are not already
+        present in the cache."""
+
+    @abstractmethod
     def find_new_threads(self, thread_ids: Iterable[str]) -> List[str]:
         """From a list of thread IDs, return those that are not already
         present in the cache."""

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -144,6 +144,19 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
                     cursor,
                 )
 
+    def find_new_posts(self, post_ids: Iterable[str]) -> List[str]:
+        return [
+            post_id
+            for post_id in post_ids
+            if (
+                row := self.execute_named(
+                    "check_post_exists", {"id": post_id}
+                ).fetchone()
+            )
+            is None
+            or not row["post_exists"]
+        ]
+
     def find_new_threads(self, thread_ids: Iterable[str]) -> List[str]:
         return [
             thread_id

--- a/notifier/database/queries/check_post_exists.sql
+++ b/notifier/database/queries/check_post_exists.sql
@@ -1,0 +1,6 @@
+SELECT EXISTS (
+  SELECT NULL FROM
+    post
+  WHERE
+    id = %(id)s
+) AS post_exists

--- a/notifier/database/queries/check_thread_exists.sql
+++ b/notifier/database/queries/check_thread_exists.sql
@@ -1,7 +1,5 @@
 SELECT EXISTS (
-  SELECT
-    1
-  FROM
+  SELECT NUll FROM
     thread
   WHERE
     id = %(id)s

--- a/notifier/database/utils.py
+++ b/notifier/database/utils.py
@@ -1,9 +1,12 @@
+import logging
 from abc import ABC
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Callable, Tuple, Type
 
 from notifier.database.drivers.base import BaseDatabaseDriver
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_driver_from_config(driver_path: str) -> Type[BaseDatabaseDriver]:
@@ -71,8 +74,11 @@ def try_cache(
     try:
         value = get()
     except catch as error:
-        print(f"{get.__name__} failed; will use value from cache")
-        print(f"Failure: {error}")
+        logger.error(
+            "try_cache failed; using value from cache %s",
+            {"get": get.__name__},
+            exc_info=error,
+        )
     if value != do_not_store:
         store(value)
 

--- a/notifier/deletions.py
+++ b/notifier/deletions.py
@@ -1,9 +1,12 @@
+import logging
 import time
 from typing import List, Set, Tuple, cast
 
 from notifier.database.drivers.base import BaseDatabaseDriver
 from notifier.types import RawPost
 from notifier.wikiconnection import Connection, ThreadNotExists
+
+logger = logging.getLogger(__name__)
 
 # A strict thread ID contains the ID of its wiki
 StrictThreadId = Tuple[str, str]
@@ -23,21 +26,32 @@ def clear_deleted_posts(
     If no users were about to be notified about a thread, there is no point
     bothering to look up whether it still exists or not.
     """
-    print(f"Clearing deleted posts from the {frequency} channel")
+    logger.info(
+        "Checking for deleted posts to clear %s", {"channel": frequency}
+    )
     posts = find_posts_to_check(frequency, database)
-    print(
-        f"Found {len(posts)} posts to check"
-        f" in {len(set(post[1] for post in posts))} threads"
+    logger.info(
+        "Found posts to check %s",
+        {
+            "post_count": len(posts),
+            "thread_count": len(set(post[1] for post in posts)),
+        },
     )
     deleted_threads, deleted_posts = delete_posts(posts, database, connection)
-    print(
-        f"Deleted {len(deleted_threads)} threads"
-        f" in {len(set(d[0] for d in deleted_threads))} wikis"
+    logger.info(
+        "Deleted threads %s",
+        {
+            "thread_count": len(deleted_threads),
+            "wiki_count": len(set(d[0] for d in deleted_threads)),
+        },
     )
-    print(
-        f"Deleted {len(deleted_posts)} posts"
-        f" in {len(set(d[1] for d in deleted_posts))} threads"
-        f" in {len(set(d[0] for d in deleted_posts))} wikis"
+    logger.info(
+        "Deleted posts %s",
+        {
+            "post_count": len(deleted_posts),
+            "thread_count": len(set(d[1] for d in deleted_posts)),
+            "wiki_count": len(set(d[0] for d in deleted_posts)),
+        },
     )
 
 

--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -33,13 +33,18 @@ def fetch_posts_with_context(
         "Found new posts in RSS %s",
         {"wiki_id": wiki_id, "post_count": len(new_posts)},
     )
+    # Remove posts that are already recorded
+    new_post_ids = database.find_new_posts(
+        [new_post[1] for new_post in new_posts]
+    )
+    new_posts = [post for post in new_posts if post[1] not in new_post_ids]
     # Find which of these posts were made in new threads
     new_thread_ids = database.find_new_threads(
         [new_post[0] for new_post in new_posts]
     )
     # Make a list of thread pages to iterate over
     # The post ID being None indicates that the full thread will be
-    # iterated; otherwise, only the page that contains the specific post is
+    # iterated; otherwise, only the page that contains the specific post
     # will be iterated
     threads_pages_to_get = [
         (thread_id, None if thread_id in new_thread_ids else post_id)
@@ -54,7 +59,7 @@ def fetch_posts_with_context(
     full_threads_already_seen: List[str] = []
     # Download each of the new threads
     logger.debug(
-        "Downloading threads %s",
+        "Found new threads to download %s",
         {"wiki_id": wiki_id, "threads_count": len(threads_pages_to_get)},
     )
     for thread_id, post_id in threads_pages_to_get:

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -109,6 +109,8 @@ def notify_active_channels(
     connection: Connection,
 ):
     """Prepare and send notifications to all activated channels."""
+    digester = Digester(config["path"]["lang"])
+    emailer = Emailer(config["gmail_username"], auth["yagmail"]["password"])
     for channel in active_channels:
         # Should this be asynchronous + parallel?
         notify_channel(
@@ -116,10 +118,8 @@ def notify_active_channels(
             current_timestamp,
             database=database,
             connection=connection,
-            digester=Digester(config["path"]["lang"]),
-            emailer=Emailer(
-                config["gmail_username"], auth["yagmail"]["password"]
-            ),
+            digester=digester,
+            emailer=emailer,
         )
 
 

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -1,5 +1,6 @@
 import re
 import time
+from datetime import datetime, timedelta
 from typing import Iterable, List, Optional, cast
 
 from notifier.config.remote import get_global_config
@@ -29,6 +30,17 @@ notification_channels = {
     "weekly": "0 0 * * 0",
     "monthly": "0 0 1 * *",
 }
+
+
+def print_time_until_next():
+    """Print the current time and the time until the next notification.
+
+    Assumes that notifications occur on the hour, every hour.
+    """
+    now = datetime.now()
+    print(f"The current time is {now}.")
+    then = now.replace(microsecond=0, second=0, minute=0) + timedelta(hours=1)
+    print(f"The next notification will be at {then}, in {then - now}.")
 
 
 def notify(

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import time
 from datetime import datetime, timedelta
@@ -21,6 +22,8 @@ from notifier.types import (
     PostInfo,
 )
 from notifier.wikiconnection import Connection
+
+logger = logging.getLogger(__name__)
 
 # Notification channels with frequency names mapping to the crontab of that
 # frequency.
@@ -53,7 +56,7 @@ def notify(
     getting data for new posts) and then triggers the relevant notification
     schedules.
     """
-    print("Checking active channels...")
+    logger.info("Checking active channels...")
     # Check which notification channels should be activated
     active_channels = [
         frequency
@@ -63,21 +66,21 @@ def notify(
     # If there are no active channels, which shouldn't happen, there is
     # nothing to do
     if len(active_channels) == 0:
-        print("No active channels")
+        logger.warning("No active channels; aborting")
         return
-    print(f"{len(active_channels)} active channels")
+    logger.info("%s active channels", len(active_channels))
 
     connection = Connection(config, database.get_supported_wikis())
 
-    print("Getting remote config...")
+    logger.info("Getting remote config...")
     get_global_config(config, database, connection)
-    print("Getting user config...")
+    logger.info("Getting user config...")
     get_user_config(config, database, connection)
 
     # Refresh the connection to add any newly-configured wikis
     connection = Connection(config, database.get_supported_wikis())
 
-    print("Getting new posts...")
+    logger.info("Getting new posts...")
     get_new_posts(database, connection)
 
     # Record the 'current' timestamp immediately after downloading posts
@@ -86,12 +89,12 @@ def notify(
     wikidot_password = auth["wikidot"]["password"]
     connection.login(config["wikidot_username"], wikidot_password)
 
-    print("Notifying...")
+    logger.info("Notifying...")
     notify_active_channels(
         active_channels, current_timestamp, config, auth, database, connection
     )
 
-    print("Cleaning up...")
+    logger.info("Cleaning up...")
     # Notifications have been sent, so perform time-insensitive maintenance
     for frequency in ["weekly", "monthly"]:
         if channel_will_be_next(notification_channels[frequency]):
@@ -134,12 +137,17 @@ def notify_channel(
     addresses: Optional[EmailAddresses] = None,
 ):
     """Execute this task's responsibilities."""
-    print(f"Executing {channel} notification channel")
+    logger.info("Activating channel %s", {"channel": channel})
     # Get config sans subscriptions for users who would be notified
     user_configs = database.get_user_configs(channel)
-    print(f"{len(user_configs)} users for {channel} channel")
+    logger.debug(
+        "Found users for channel %s",
+        {"user_count": len(user_configs), "channel": channel},
+    )
     # Notify each user on this frequency channel
+    notified_users = 0
     for user in user_configs:
+        logger.debug("Making digest for user %s", user)
         # Get new posts for this user
         posts = database.get_new_posts_for_user(
             user["user_id"],
@@ -147,13 +155,24 @@ def notify_channel(
         )
         apply_overrides(posts, database.get_global_overrides())
         post_count = len(posts["thread_posts"]) + len(posts["post_replies"])
-        print(
-            "[{}] Notifying {} about {} posts via {}".format(
-                channel, user["username"], post_count, user["delivery"]
-            )
+        logger.debug(
+            "Found posts for notification %s",
+            {
+                "username": user["username"],
+                "post_count": post_count,
+                "channel": channel,
+            },
         )
         if post_count == 0:
             # Nothing to notify this user about
+            logger.debug(
+                "Aborting notification %s",
+                {
+                    "user": user["username"],
+                    "channel": channel,
+                    "reason": "no posts",
+                },
+            )
             continue
         # Extract the 'last notification time' that will be recorded -
         # it is the timestamp of the most recent post this user is
@@ -169,22 +188,43 @@ def notify_channel(
         subject, body = digester.for_user(user, posts)
         # Send the digests via PM to PM-subscribed users
         if user["delivery"] == "pm":
+            logger.debug(
+                "Sending notification %s",
+                {"user": user["username"], "via": "pm", "channel": channel},
+            )
             connection.send_message(user["user_id"], subject, body)
         # Send the digests via email to email-subscribed users
         if user["delivery"] == "email":
             if addresses is None:
                 # Only get the contacts when there is actually a user who
                 # needs to be emailed
+                logger.info("Retrieving email contacts")
                 addresses = connection.get_contacts()
+                logger.debug(
+                    "Retrieved email contacts %s",
+                    {"address_count": len(addresses)},
+                )
             try:
+                logger.debug("Using cached email contacts")
                 address = addresses[user["username"]]
             except KeyError:
                 # This user requested to be notified via email but
                 # hasn't added the notification account as a contact,
                 # meaning their email address is unknown
-                print(f"{user['username']} is not a back-contact")
+                logger.warning(
+                    "Aborting notification %s",
+                    {
+                        "user": user["username"],
+                        "channel": channel,
+                        "reason": "not a back-contact",
+                    },
+                )
                 # They'll have to fix this themselves
                 continue
+            logger.debug(
+                "Sending notification %s",
+                {"user": user["username"], "via": "email", "channel": channel},
+            )
             emailer.send(address, subject, body)
         # Immediately after sending the notification, record the user's
         # last notification time
@@ -193,7 +233,19 @@ def notify_channel(
         database.store_user_last_notified(
             user["user_id"], last_notified_timestamp
         )
-    print(f"Notified {len(user_configs)} users in {channel} channel")
+        logger.debug(
+            "Recorded notification %s",
+            {
+                "username": user["username"],
+                "recorded_timestamp": last_notified_timestamp,
+                "channel": channel,
+            },
+        )
+        notified_users += 1
+    logger.info(
+        "Finished notifying channel %s",
+        {"channel": channel, "users_notified_count": notified_users},
+    )
 
 
 def apply_overrides(

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import time
-from datetime import datetime, timedelta
 from typing import Iterable, List, Optional, cast
 
 from notifier.config.remote import get_global_config
@@ -33,17 +32,6 @@ notification_channels = {
     "weekly": "0 0 * * 0",
     "monthly": "0 0 1 * *",
 }
-
-
-def print_time_until_next():
-    """Print the current time and the time until the next notification.
-
-    Assumes that notifications occur on the hour, every hour.
-    """
-    now = datetime.now()
-    print(f"The current time is {now}.")
-    then = now.replace(microsecond=0, second=0, minute=0) + timedelta(hours=1)
-    print(f"The next notification will be at {then}, in {then - now}.")
 
 
 def notify(
@@ -99,8 +87,6 @@ def notify(
     for frequency in ["weekly", "monthly"]:
         if channel_will_be_next(notification_channels[frequency]):
             clear_deleted_posts(frequency, database, connection)
-
-    print_time_until_next()
 
 
 def notify_active_channels(

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -1,9 +1,12 @@
+import logging
 import re
 from typing import Iterable, List, Optional, Tuple, cast
 
 from bs4.element import Tag
 
 from notifier.types import RawPost, RawThreadMeta
+
+logger = logging.getLogger(__name__)
 
 
 def parse_thread_meta(thread: Tag) -> RawThreadMeta:
@@ -74,7 +77,14 @@ def parse_thread_page(thread_id: str, thread_page: Tag) -> List[RawPost]:
             continue
         posted_timestamp = get_timestamp_from_post_info(post_info)
         if posted_timestamp is None:
-            print(f"Couldn't read timestamp for {thread_id}/{post_id}")
+            logger.warning(
+                "Skipping caching post %s",
+                {
+                    "thread_id": thread_id,
+                    "post_id": post_id,
+                    "reason": "could not parse timestamp",
+                },
+            )
             continue
         post_title = cast(Tag, post.find(class_="title")).get_text().strip()
         post_snippet = make_post_snippet(post)

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Iterable, Iterator, List, Optional, Union, cast
 
 import requests
@@ -17,6 +18,8 @@ from notifier.types import (
     SupportedWikiConfig,
     WikidotResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 listpages_div_class = "listpages-div-wrap"
 
@@ -91,7 +94,16 @@ class Connection:
         if response["status"] == "no_thread":
             raise ThreadNotExists
         if response["status"] != "ok":
-            print(response)
+            logger.error(
+                "Bad response from Wikidot %s",
+                {
+                    "wiki_id": wiki_id,
+                    "secure": secure,
+                    "module_name": module_name,
+                    "request_kwargs": kwargs,
+                    "response": response,
+                },
+            )
             raise RuntimeError(response.get("message") or response["status"])
         return response
 
@@ -230,7 +242,7 @@ class Connection:
 
     def login(self, username: str, password: str) -> None:
         """Log in to a Wikidot account."""
-        print("Logging in...")
+        logger.info("Logging in...")
         self.post(
             "https://www.wikidot.com/default--flow/login__LoginPopupScreen",
             data=dict(


### PR DESCRIPTION
Running the notifier once per hour every hour automatically is fine if the script is running continuously, but that's only true in one use case:

- For tests, I want to be able to execute any notification channel immediately and once only.
- In production using Lambdas, I want to be able to execute an automatically-determined set of channels immediately and once only.
- In production on a normal server, I want to run as a continuous service (but I don't actually want to do this).

I need a method of running the script instantly that can support the first two use cases.

- [ ] Be able to run a specified channel or channels immediately
- [ ] Be able to run an automatically-determined set of channels immediately
- [ ] Document usage