### PR TITLE
Pin MySQL version

### DIFF
--- a/.github/auth.ci.toml
+++ b/.github/auth.ci.toml
@@ -1,5 +1,5 @@
 wikidot_password = ""
 gmail_password = ""
-mysql_host = "localhost"
+mysql_host = "127.0.0.1"
 mysql_username = "root"
 mysql_password = "root"

--- a/.github/auth.ci.toml
+++ b/.github/auth.ci.toml
@@ -1,5 +1,5 @@
 wikidot_password = ""
 gmail_password = ""
-mysql_host = "127.0.0.1"
+mysql_host = "localhost"
 mysql_username = "root"
 mysql_password = "root"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup MySQL
+        id: setup-mysql
+        run: |
+          container_id=$( \
+            docker run -d \
+            -p 3306:3306 \
+            -e MYSQL_ROOT_PASSWORD=root \
+            -e MYSQL_USER=root \
+            -e MYSQL_PASSWORD=root \
+            mysql:5.6.17 \
+          )
+          container_ip=$( \
+            docker inspect -f \
+            '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+            $container_id \
+          )
+          sed -i "s/localhost/$container_ip/g" .github/auth.ci.toml
+          echo "::set-output name=container-ip::$container_ip"
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -43,16 +61,16 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            venv-${{ runner.os }}-
       - name: Install Python dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
-      - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          character set server: utf8mb4
-          collation server: utf8mb4_bin
-          mysql version: '5.6.17'
-          mysql database: wikidot_notifier_test
-          mysql root password: root
+      - name: Create MySQL database
+        run: |
+          mysql \
+          -h${{ steps.setup-mysql.outputs.container-ip }} \
+          -proot -uroot \
+          -e "CREATE DATABASE wikidot_notifier_test;"
       - name: Run tests
-        run: poetry run pytest --notifier-config config.toml --notifier-auth .github/auth.ci.toml
+        run: poetry run pytest -x --notifier-config config.toml --notifier-auth .github/auth.ci.toml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,13 @@ jobs:
       - name: Install Python dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
-      - name: Start MySQL
-        run: |
-          sudo systemctl start mysql.service
-          mysql -uroot -proot -e 'CREATE DATABASE wikidot_notifier_test;'
+      - name: Setup MySQL
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          character set server: utf8mb4
+          collation server: utf8mb4_bin
+          mysql version: '5.6.17'
+          mysql database: wikidot_notifier_test
+          mysql root password: root
       - name: Run tests
         run: poetry run pytest --notifier-config config.toml --notifier-auth .github/auth.ci.toml

--- a/README.md
+++ b/README.md
@@ -31,37 +31,16 @@ In addition to the config file based on the one provided in this
 repository, notifier requires an additional authentication file to provide
 passwords etc. for the various services it requires.
 
-See [docs/auth.md](/docs/auth.md) for more information.
+See [docs/auth.md](/docs/auth.md) for more information and instructions.
 
 ## Database setup
 
-If using the MySQL database driver, MySQL will need to be installed, and a
-MySQL server will need to be running somewhere.
+For local development and testing, notifier requires a database to be set
+up on a version of MySQL that is compatible with Amazon Aurora Serverless
+v1.
 
-A new user will need to be created for the notifier, replacing the
-placeholders with the MySQL-specific credentials supplied above:
-
-```sql
-CREATE USER '<username>'@'<host>' IDENTIFIED BY '<password>';
-```
-
-Create the database, with the database's name matching the name in the
-config file (default: `wikidot_notifier`), and grant the new user access to
-it:
-
-```sql
-CREATE DATABASE `<name>` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin;
-GRANT ALL PRIVILEGES ON `<name>`.* TO '<username>'@'<host>';
-```
-
-In order to run tests, a test database will also need to be created. The
-name of this database is the same as the configured name, with "_test"
-appended:
-
-```sql
-CREATE DATABASE `<name>_test` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin;
-GRANT ALL PRIVILEGES ON `<name>_test`.* TO '<username>'@'<host>';
-```
+See [docs/database.md](/docs/database.md) for more information and
+instructions.
 
 ## Execution
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,89 @@
+# Database setup
+
+notifier uses MySQL. It and the database need to be set up before it can
+operate, or before tests can be run.
+
+This document assumes some familiarity with
+[Docker](https://www.docker.com/).
+
+## Setting up MySQL
+
+notifier is designed to use [Amazon Aurora Serverless
+v1](https://aws.amazon.com/rds/aurora/serverless/) during production. The
+latest version of MySQL supported by Aurora Serverless is 5.6.10 (for
+reference, the latest version of MySQL at the time of writing is 8.0.26).
+For this reason, a compatible version of MySQL is needed for local
+development.
+
+[Docker](https://www.docker.com/) is used for pinning the MySQL version,
+and to avoid this version conflicting with any MySQL already installed on
+your system.
+
+The earliest version of MySQL 5.6 available in the official MySQL Docker
+registry is 5.6.17; therefore, although it's not ideal, I recommend running
+tests locally against this version of MySQL. This is also the version that
+[I use in CI](/.github/workflows/tests.yml).
+
+Create the MySQL Server container:
+
+```shell
+docker create --name notifier_mysql \
+  -p 3306:3306 \
+  -e MYSQL_ROOT_PASSWORD=root \
+  mysql:5.6.17
+```
+
+For an ephemeral, development-only, containerised MySQL installation I'm
+cool with just setting the root password insecurely like this. Obviously
+don't do this in production.
+
+Start the container:
+
+```shell
+docker start notifier_mysql
+```
+
+To access the database using the MySQL client:
+
+```shell
+mysql -h127.0.0.1 -uroot -proot
+```
+
+If `127.0.0.1` doesn't work you may need to find the IP of the Docker
+container and use that instead:
+
+```shell
+docker inspect \
+  -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+  notifier_mysql
+```
+
+Once inside the database server, you can create the database.
+
+## Creating the database
+
+A new user will need to be created for the notifier, replacing the
+placeholders with the MySQL-specific credentials supplied [during
+authentication](/docs/auth.md):
+
+```sql
+CREATE USER '<username>'@'<host>' IDENTIFIED BY '<password>';
+```
+
+Create the database, with the database's name matching the name in the
+config file (default: `wikidot_notifier`), and grant the new user access to
+it:
+
+```sql
+CREATE DATABASE `<name>` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+GRANT ALL PRIVILEGES ON `<name>`.* TO '<username>'@'<host>';
+```
+
+In order to run tests, a test database will also need to be created. The
+name of this database is the same as the configured name, with "_test"
+appended:
+
+```sql
+CREATE DATABASE `<name>_test` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+GRANT ALL PRIVILEGES ON `<name>_test`.* TO '<username>'@'<host>';
+```

--- a/notifier/database/queries/create_tables.script.sql
+++ b/notifier/database/queries/create_tables.script.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS wiki (
   PRIMARY KEY (id),
   id     VARCHAR(50)  NOT NULL,
   name   VARCHAR(200) NOT NULL,
-  secure TINYINT(1)   NOT NULL CHECK (secure IN (0, 1))
+  secure TINYINT(1)   NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS category (
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS thread (
   category_id       VARCHAR(200),
   creator_username  VARCHAR(20),
   created_timestamp INT UNSIGNED NOT NULL,
-  is_deleted        TINYINT(1)   NOT NULL CHECK (is_deleted IN (0, 1)) DEFAULT 0
+  is_deleted        TINYINT(1)   NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS post (
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS post (
   snippet          VARCHAR(200) NOT NULL,
   user_id          VARCHAR(20)  NOT NULL,
   username         VARCHAR(20)  NOT NULL,
-  is_deleted       TINYINT(1)   NOT NULL CHECK (is_deleted IN (0, 1)) DEFAULT 0,
+  is_deleted       TINYINT(1)   NOT NULL DEFAULT 0,
   FOREIGN KEY (thread_id)      REFERENCES thread (id),
   FOREIGN KEY (parent_post_id) REFERENCES post (id)
 );


### PR DESCRIPTION
The latest version of MySQL supported by Amazon Aurora Serverless v1 is 5.6.10a. The current version as of the time of writing, and the version that is currently installed both on my computer and on GitHub Actions, is 8.0.26. I need to backdate both.

The closest version with an image available on Docker is 5.6.17. I can only hope that that's fine. If it turns out that it's not, the only thing I can do is make my own Docker image - I'd really rather not do that.

- [x] Pin MySQL version in GitHub Actions runner: https://github.com/marketplace/actions/setup-mysql
- [x] Pin MySQL version locally
  - I will likely have to use Docker for this.
- [x] Document setup requirements
- [x] Switch `utf8mb4_0900_bin` for `utf8mb4_bin` (5.6.10 doesn't support it)

Merges into #17 