### PR TITLE
Set initial user timestamp

### DIFF
--- a/notifier/config/user.py
+++ b/notifier/config/user.py
@@ -27,7 +27,7 @@ user_id = "%%created_by_id%%"
 frequency = "%%form_raw{frequency}%%"
 language = "%%form_raw{language}%%"
 delivery = "%%form_raw{method}%%"
-page_created_date = """%%created_at%%"""
+user_base_notified = """%%created_at%%"""
 subscriptions = """
 %%form_data{subscriptions}%%"""
 unsubscriptions = """
@@ -111,7 +111,7 @@ def parse_raw_user_config(
     assert "user_id" in config
     # Parse page date to approximate timestamp and coerce to int
     # TODO Move hardcoded date to config
-    config["page_created_date"] = user_timestamp or 1627277777
+    config["user_base_notified"] = max(user_timestamp or 0, 1627277777)
     config["subscriptions"] = parse_subscriptions(
         config.get("subscriptions", ""), 1
     )

--- a/notifier/config/user.py
+++ b/notifier/config/user.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 from typing import List, Tuple, Union, cast
 
 import tomlkit
@@ -26,6 +27,7 @@ user_id = "%%created_by_id%%"
 frequency = "%%form_raw{frequency}%%"
 language = "%%form_raw{language}%%"
 delivery = "%%form_raw{method}%%"
+page_created_date = """%%created_at|%Y-%m-%d%%"""
 subscriptions = """
 %%form_data{subscriptions}%%"""
 unsubscriptions = """
@@ -102,6 +104,16 @@ def parse_raw_user_config(raw_config: str) -> Tuple[RawUserConfig, str]:
     assert isinstance(slug, str)
     assert "username" in config
     assert "user_id" in config
+    # Parse page date to approximate timestamp and coerce to int
+    config["page_created_date"] = int(
+        time.mktime(
+            time.strptime(
+                # TODO Move hardcoded date to config
+                config.get("page_created_date", "2021-09-01") + " UTC",
+                "%Y-%m-%d %Z",
+            )
+        )
+    )
     config["subscriptions"] = parse_subscriptions(
         config.get("subscriptions", ""), 1
     )

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -280,6 +280,13 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
                         },
                         cursor,
                     )
+                self.execute_named(
+                    "store_new_user_last_notified",
+                    {
+                        "user_id": user_config["user_id"],
+                        "notified_timestamp": user_config["page_created_date"],
+                    },
+                )
 
     def store_user_last_notified(
         self, user_id: str, last_notified_timestamp: int

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -284,7 +284,9 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
                     "store_new_user_last_notified",
                     {
                         "user_id": user_config["user_id"],
-                        "notified_timestamp": user_config["page_created_date"],
+                        "notified_timestamp": user_config[
+                            "user_base_notified"
+                        ],
                     },
                 )
 

--- a/notifier/database/queries/store_new_user_last_notified.sql
+++ b/notifier/database/queries/store_new_user_last_notified.sql
@@ -1,0 +1,6 @@
+INSERT INTO
+  user_last_notified
+  (user_id, notified_timestamp)
+VALUES
+  (%(user_id)s, %(notified_timestamp)s)
+ON DUPLICATE KEY UPDATE user_id=user_id

--- a/notifier/database/queries/store_new_user_timestamp.sql
+++ b/notifier/database/queries/store_new_user_timestamp.sql
@@ -1,0 +1,7 @@
+INSERT INTO
+  user_last_notified
+  (user_id, notified_timestamp)
+VALUES
+  (%(user_id)s, %(notified_timestamp)s)
+-- If the user already exists, fall back to no-op
+ON DUPLICATE KEY UPDATE user_id=user_id

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -28,7 +28,7 @@ def parse_thread_meta(thread: Tag) -> RawThreadMeta:
     creator_username = get_user_from_nametag(
         cast(Tag, statistics.find(class_="printuser"))
     )[1]
-    created_timestamp = get_timestamp_from_post_info(statistics)
+    created_timestamp = get_timestamp(statistics)
     if created_timestamp is None:
         raise ValueError("No timestamp for thread")
     return {
@@ -81,7 +81,7 @@ def parse_thread_page(thread_id: str, thread_page: Tag) -> List[RawPost]:
             # Wikidot accepts 'Anonymous' as a null value to [[user]] syntax
             author_name = "Anonymous"
 
-        posted_timestamp = get_timestamp_from_post_info(post_info)
+        posted_timestamp = get_timestamp(post_info)
         if posted_timestamp is None:
             logger.warning(
                 "Could not parse timestamp for post %s",
@@ -176,12 +176,12 @@ def get_user_from_nametag(nametag: Tag) -> Tuple[Optional[str], Optional[str]]:
     return None, None
 
 
-def get_timestamp_from_post_info(info: Tag) -> Optional[int]:
-    """Gets a post's timestamp from its post info.
+def get_timestamp(element: Tag) -> Optional[int]:
+    """Retrieves a Wikidot timestamp.
 
     Returns None if this fails, though I see no reason that it should.
     """
-    post_date = cast(Tag, info.find(class_="odate"))
+    post_date = cast(Tag, element.find(class_="odate"))
     try:
         posted_timestamp = [
             int(css_class.lstrip("time_"))

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -94,6 +94,7 @@ class RawUserConfig(TypedDict):
     frequency: str
     language: str
     delivery: DeliveryMethod
+    page_created_date: int
     subscriptions: List[Subscription]
     unsubscriptions: List[Subscription]
 

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -94,7 +94,7 @@ class RawUserConfig(TypedDict):
     frequency: str
     language: str
     delivery: DeliveryMethod
-    page_created_date: int
+    user_base_notified: int
     subscriptions: List[Subscription]
     unsubscriptions: List[Subscription]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -668,6 +668,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-emoji"
+version = "1.2.4"
+description = "Typing stubs for emoji"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-pymysql"
 version = "1.0.2"
 description = "Typing stubs for PyMySQL"
@@ -753,7 +761,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0222a07a621af5e142ab6fc6d943c6727591fda958f1bf105b85b228161fb580"
+content-hash = "293bd0c96bdb65ef0548cbc7a814c550a91804fb4a3c5cd2e01063c4d71b01fb"
 
 [metadata.files]
 appdirs = [
@@ -1161,6 +1169,10 @@ tomlkit = [
 types-beautifulsoup4 = [
     {file = "types-beautifulsoup4-4.9.1.tar.gz", hash = "sha256:8217c59aa27243936bce597b06b5d50d89229d50a02197b44c4ac487c4009a48"},
     {file = "types_beautifulsoup4-4.9.1-py3-none-any.whl", hash = "sha256:7d9a17e91337325eef2967d6cb5f0dd5047c274532f84d2430da45d5f65b1783"},
+]
+types-emoji = [
+    {file = "types-emoji-1.2.4.tar.gz", hash = "sha256:a7426bcbf0bc8d0809d49f1807e5cb8582f87d4a681b0ae80103f6eca5492e81"},
+    {file = "types_emoji-1.2.4-py3-none-any.whl", hash = "sha256:9fb171f36ef167aaec899e5d42b78dea19c94f50553351731b6997b6e70f7b05"},
 ]
 types-pymysql = [
     {file = "types-PyMySQL-1.0.2.tar.gz", hash = "sha256:8a814d8391934009a0e1a3a344c9295e6a7fda76a6df0c469b0a13f0ae6e79df"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ PyMySQL = "^1.0.2"
 types-PyMySQL = "^1.0.2"
 boto3 = "^1.18.41"
 typing-extensions = "^3.10.0"
+types-emoji = "^1.2.4"
 
 [tool.poetry.dev-dependencies]
 black = "^21.7b0"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -51,7 +51,7 @@ def sample_database(
             "frequency",
             "language",
             "delivery",
-            "page_created_date",
+            "user_base_notified",
             "subscriptions",
             "unsubscriptions",
         ],

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -51,10 +51,11 @@ def sample_database(
             "frequency",
             "language",
             "delivery",
+            "page_created_date",
             "subscriptions",
             "unsubscriptions",
         ],
-        [("1", "MyUsername", "hourly", "en", "pm", subs, unsubs)],
+        [("1", "MyUsername", "hourly", "en", "pm", 1, subs, unsubs)],
     )
     sample_wikis: List[SupportedWikiConfig] = construct(
         ["id", "name", "secure"], [("my-wiki", "My Wiki", 1)]
@@ -183,3 +184,16 @@ def test_deleted_thread(sample_database: BaseDatabaseDriver):
     posts = sample_database.get_new_posts_for_user("1", (0, 100))
     assert "t-1" not in [reply["thread_id"] for reply in posts["post_replies"]]
     assert "t-1" not in [post["thread_id"] for post in posts["thread_posts"]]
+
+
+def test_initial_notified_timestamp(sample_database: MySqlDriver):
+    """Test that the initial last notified timestamp for a user is set."""
+    with sample_database.transaction() as cursor:
+        cursor.execute(
+            """
+            SELECT notified_timestamp
+            FROM user_last_notified
+            WHERE user_id='1'
+            """
+        )
+        assert (cursor.fetchone() or {})["notified_timestamp"] == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -189,11 +189,31 @@ def test_deleted_thread(sample_database: BaseDatabaseDriver):
 def test_initial_notified_timestamp(sample_database: MySqlDriver):
     """Test that the initial last notified timestamp for a user is set."""
     with sample_database.transaction() as cursor:
-        cursor.execute(
-            """
-            SELECT notified_timestamp
-            FROM user_last_notified
-            WHERE user_id='1'
-            """
+
+        def check_timestamp(n):
+            cursor.execute(
+                """
+                SELECT notified_timestamp
+                FROM user_last_notified
+                WHERE user_id='1'
+                """
+            )
+            assert (cursor.fetchone() or {})["notified_timestamp"] == n
+
+        check_timestamp(1)
+        sample_database.execute_named(
+            "store_user_last_notified",
+            {
+                "user_id": "1",
+                "notified_timestamp": 2,
+            },
         )
-        assert (cursor.fetchone() or {})["notified_timestamp"] == 1
+        check_timestamp(2)
+        sample_database.execute_named(
+            "store_new_user_last_notified",
+            {
+                "user_id": "1",
+                "notified_timestamp": 3,
+            },
+        )
+        check_timestamp(2)


### PR DESCRIPTION
A user's timestamp is the timestamp of the post that they were last notified about, used to ensure that they are only ever notified about new posts made since then.

A user's initial timestamp is 0. This was to ensure that they'd be immediately caught up on all posts they missed from before they subscribed to the service. However, I quickly realise that this was a *terrible* idea, as it accrues *so many posts* for a user incredibly quickly. And I've only been running for about a day.

- [x] Set a user's initial timestamp to the timestamp at which they created their user config page
  - The exact timestamp is not easy to get - not without compromising the current config getting method. But I don't need an exact timestamp - even just a date would be fine. I can get that via get_text easily.
- [x] Document this behaviour in the FAQ
- [x] Modify the existing database to match

In the future I would like to have a second default timestamp configured for the tool, and the highest of these two values would be used as a user's initial timestamp. This would allow a subsequent service run by someone else using the same software and config wiki to take over from me in the case this project abruptly ends - by setting their instance's timestamp to the timestamp of my service's final notification, the takeover could be seamless.