### PR TITLE
Add a test channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,22 @@ auth file with dummy secrets, used for CI tests, can be found at
 The service will run continuously and activate an automatically-determined
 set of notification channels each hour.
 
-To activate a channel or multiple channels immediately and once only, add
-the `--execute-now` switch followed by any of `hourly`, `daily`, `weekly`
-and `monthly`.
-
 To activate an automatically-determined set of channels immediately and
 once only, add the `--execute-now` switch with no parameter. Note that this
 must be run during the first minute of an hour to match any channels.
+
+To activate a manually-chosen channel or set of channels immediately and
+once only, even at a time when such channel would not normally be
+activated, add the `--execute-now` switch followed by any of `hourly`,
+`daily`, `weekly`, `monthly` and `test`.
+
+The `test` channel will never be activated during normal usage. Note that
+user config setting for the `test` channel is hidden, and can be selected
+by executing the following JavaScript while editing a user config page:
+
+```js
+document.querySelector("[name=field-frequency]").value = "test"
+```
 
 ## Remote deployment
 

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -2,8 +2,8 @@ import argparse
 import logging
 from typing import List, Optional, Tuple
 
-from notifier.__main__ import main
 from notifier.config.local import read_local_auth, read_local_config
+from notifier.main import main
 from notifier.notify import notification_channels
 from notifier.types import AuthConfig, LocalConfig
 

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -115,7 +115,7 @@ class Digester:
             "daily": lexicon["frequency_daily"],
             "weekly": lexicon["frequency_weekly"],
             "monthly": lexicon["frequency_monthly"],
-        }[user["frequency"]]
+        }.get(user["frequency"], "")
         intro = lexicon["intro"].format(
             frequency=frequency,
             site=lexicon["site"],

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -31,6 +31,7 @@ notification_channels = {
     "daily": "0 0 * * *",
     "weekly": "0 0 * * 0",
     "monthly": "0 0 1 * *",
+    "test": "x x x x x",  # pycron accepts this value but it never passes
 }
 
 


### PR DESCRIPTION
I need a test channel. When I run a sample execution on the command line, if I choose no channels, the bulk of the codebase will not execute. But if I choose any channel, I will notify users on that channel, which I don't want to do if I'm just testing.

A separate test channel should be created, used for testing. This will only notify users who want to be notified on the test channel (hopefully just me).

I should also add a dry run setting, which will be useful when I don't want to test the actual sending notifications bit.

- [x] Add a test channel
- [x] Document the test channel (because it will have to be exposed to users)
- [x] Ensure that the test channel can deliver a notification

Merges into #20 because I need this test there