### PR TITLE
Use forum posts module for iterating through posts

### DIFF
--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -98,7 +98,8 @@ def fetch_posts_with_context(
             )
             continue
         logger.debug(
-            "Downloading thread %s",
+            "Downloading thread%s %s",
+            " containing post" if post_id is not None else "",
             {"wiki_id": wiki_id, "thread_id": thread_id, "post_id": post_id},
         )
         for post_index, thread_or_post in enumerate(
@@ -141,30 +142,16 @@ def fetch_posts_with_context(
         if post_id is None:
             # If the full thread was crawled, mark it as seen
             full_threads_already_seen.append(thread_id)
-            logger.debug(
-                "Downloaded thread %s",
-                {
-                    "wiki_id": wiki_id,
-                    "thread_id": thread_id,
-                    "cumulative_post_count": len(posts_already_seen),
-                    "cumulative_full_thread_count": len(
-                        full_threads_already_seen
-                    ),
-                },
-            )
-        else:
-            logger.debug(
-                "Downloaded thread page containing post %s",
-                {
-                    "wiki_id": wiki_id,
-                    "thread_id": thread_id,
-                    "post_id": post_id,
-                    "cumulative_post_count": len(posts_already_seen),
-                    "cumulative_full_thread_count": len(
-                        full_threads_already_seen
-                    ),
-                },
-            )
+        logger.debug(
+            "Downloaded thread%s %s",
+            " containing post" if post_id is not None else "",
+            {
+                "wiki_id": wiki_id,
+                "thread_id": thread_id,
+                "cumulative_post_count": len(posts_already_seen),
+                "cumulative_full_thread_count": len(full_threads_already_seen),
+            },
+        )
 
 
 def fetch_post_context(connection: Connection, wiki_id: str, thread_id: str):

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -1,11 +1,11 @@
 import logging
 import re
-from typing import Iterable, List, Optional, Tuple, cast
+from typing import Iterable, List, Optional, Tuple, Union, cast
 
+from bs4 import BeautifulSoup
 from bs4.element import Tag
 
 from notifier.types import RawPost, RawThreadMeta
-from notifier.wikiconnection import count_pages
 
 logger = logging.getLogger(__name__)
 
@@ -193,3 +193,25 @@ def get_timestamp(element: Tag) -> Optional[int]:
     except (IndexError, ValueError):
         return None
     return posted_timestamp
+
+
+def count_pages(module_result: Union[str, Tag]) -> int:
+    """Counts the pages in a Wikidot module.
+
+    Takes the HTML (as text or soup) of the output of any module that can
+    return with a pager, and reads the text of the last page button to get
+    the page number.
+
+    If a pager is not present, the page count is assumed to be 1.
+    """
+    if isinstance(module_result, str):
+        module_result = BeautifulSoup(module_result, "html.parser")
+    page_selectors = cast(Tag, module_result.find(class_="pager"))
+    if not page_selectors:
+        # There are no page selectors if there is only one page
+        return 1
+    final_page_selector = cast(
+        Tag,
+        cast(Tag, page_selectors.select(".target:nth-last-child(2)")[0]).a,
+    )
+    return int(final_page_selector.get_text())

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, Optional, Tuple, cast
 from bs4.element import Tag
 
 from notifier.types import RawPost, RawThreadMeta
+from notifier.wikiconnection import count_pages
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ def parse_thread_meta(thread: Tag) -> RawThreadMeta:
         "title": list(breadcrumbs.stripped_strings)[-1].strip(" »"),
         "creator_username": creator_username,
         "created_timestamp": created_timestamp,
+        "page_count": count_pages(thread),
     }
 
 

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -120,6 +120,7 @@ class RawThreadMeta(TypedDict):
     title: str
     creator_username: Optional[str]
     created_timestamp: int
+    page_count: int
 
 
 class RawPost(TypedDict):

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from bs4.element import Tag
 
 from notifier.parsethread import (
+    count_pages,
     get_user_from_nametag,
     parse_thread_meta,
     parse_thread_page,
@@ -329,25 +330,3 @@ class Connection:
             address = address_cell.get_text().strip()
             addresses[username.strip()] = address
         return addresses
-
-
-def count_pages(module_result: Union[str, Tag]) -> int:
-    """Counts the pages in a Wikidot module.
-
-    Takes the HTML (as text or soup) of the output of any module that can
-    return with a pager, and reads the text of the last page button to get
-    the page number.
-
-    If a pager is not present, the page count is assumed to be 1.
-    """
-    if isinstance(module_result, str):
-        module_result = BeautifulSoup(module_result, "html.parser")
-    page_selectors = cast(Tag, module_result.find(class_="pager"))
-    if not page_selectors:
-        # There are no page selectors if there is only one page
-        return 1
-    final_page_selector = cast(
-        Tag,
-        cast(Tag, page_selectors.select(".target:nth-last-child(2)")[0]).a,
-    )
-    return int(final_page_selector.get_text())

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -319,19 +319,18 @@ class Connection:
         return addresses
 
 
-def count_pages(module_result: str) -> int:
+def count_pages(module_result: Union[str, Tag]) -> int:
     """Counts the pages in a Wikidot module.
 
-    Takes the HTML (as text) of the output of any module that can return
-    with a pager, and reads the text of the last page button to get the
-    page number.
+    Takes the HTML (as text or soup) of the output of any module that can
+    return with a pager, and reads the text of the last page button to get
+    the page number.
 
     If a pager is not present, the page count is assumed to be 1.
     """
-    page_selectors = cast(
-        Tag,
-        BeautifulSoup(module_result, "html.parser").find(class_="pager"),
-    )
+    if isinstance(module_result, str):
+        module_result = BeautifulSoup(module_result, "html.parser")
+    page_selectors = cast(Tag, module_result.find(class_="pager"))
     if not page_selectors:
         # There are no page selectors if there is only one page
         return 1

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -131,6 +131,14 @@ class Connection:
         key for each page. 1 for the vast majority of modules; often equal
         to the perPage value for ListPages.
         """
+        logger.debug(
+            "Paginated module %s",
+            {
+                "index": kwargs.get(index_key, starting_index),
+                "module_name": module_name,
+                "wiki_id": wiki,
+            },
+        )
         first_page = self.module(wiki, module_name, **kwargs)
         yield first_page
         page_selectors = cast(
@@ -153,6 +161,14 @@ class Connection:
         # End at the final page plus one because range() is head exclusive
         for page_index in range(starting_index + 1, final_page_index + 1):
             kwargs.update({index_key: page_index * index_increment})
+            logger.debug(
+                "Paginated module %s",
+                {
+                    "index": kwargs[index_key],
+                    "module_name": module_name,
+                    "wiki_id": wiki,
+                },
+            )
             yield self.module(wiki, module_name, **kwargs)
 
     def listpages(


### PR DESCRIPTION
The module that I've been using `forum/ForumViewThreadModule` does 3 things:

1. It shows information about a thread (the thread header at the top of the page)
2. It shows information about the first page of a thread
3. If a post is specified, it shows information about the page of a thread containing that post

However, it is not paginated, which means it cannot be iterated over to get more posts. This is the cause of a fundamental issue in my procedure: I attempt to iterate this module to download the pages of a thread one-by-one, but because it does not support pagination, I actually download the first page of the thread as many times as there are pages in the thread. I noticed this by observing sets of posts being repeated in the download log (rather than by observing lots of missing posts as you might expect...)

My pagination technique for this module was based on observation of network requests in the browser when clicking thread page selectors. These observations are valid, they just apply to a different module, `forum/ForumViewThreadPostsModule`, which I hadn't noticed because of its similar name.

- [x] Use `forum/ForumViewThreadPostsModule` for iterating thread pages

Merge after #21 