### PR TITLE
Cache time instantly

### DIFF
--- a/notifier/main.py
+++ b/notifier/main.py
@@ -10,6 +10,7 @@ from notifier.notify import (
     notify,
     pick_channels_to_notify,
 )
+from notifier.timing import now
 from notifier.types import AuthConfig, LocalConfig
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 def main(config: LocalConfig, auth: AuthConfig, execute_now: List[str] = None):
     """Main executor, supposed to be called via command line."""
+
+    logging.info("The current time is %s", now)
 
     # Database stores forum posts and caches subscriptions
     DatabaseDriver = resolve_driver_from_config(config["database"]["driver"])

--- a/notifier/timing.py
+++ b/notifier/timing.py
@@ -2,20 +2,23 @@ from datetime import datetime, timedelta
 
 import pycron
 
+# Store the current time as soon as possible
+now = datetime.now()
+
 
 def channel_is_now(crontab: str):
     """Checks if the given notification channel should be activated right
     now."""
-    return pycron.is_now(crontab)
+    return pycron.is_now(crontab, now)
 
 
 def channel_will_be_next(crontab: str):
     """Checks if the given notification channel will be activated on the
     next channel, in an hour."""
-    return pycron.is_now(crontab, dt=datetime.now() + timedelta(hours=1))
+    return pycron.is_now(crontab, now + timedelta(hours=1))
 
 
 def channel_was_previous(crontab: str):
     """Checks if the given notification channel was activated on the
     previous channel an hour ago (in theory)."""
-    return pycron.is_now(crontab, dt=datetime.now() - timedelta(hours=1))
+    return pycron.is_now(crontab, now - timedelta(hours=1))


### PR DESCRIPTION
The current time, when it comes to checking which notification channels should be activated, is only checked once the notification process starts. However, there are things that can happen before that - for example, applying migrations to the database, which could take a long time. The current time needs to be cached as soon as possible.