### PR TITLE
Automatic moderation

### DIFF
--- a/notifier/config/user.py
+++ b/notifier/config/user.py
@@ -81,17 +81,14 @@ def fetch_user_configs(
                 exc_info=error,
             )
             continue
-        if (
-            ":" not in slug
-            or slug.split(":")[1].casefold() != config["username"].casefold()
-        ):
+        if ":" not in slug or slug.split(":")[1] != config["user_id"]:
             # Only accept configs for the user who created the page
             logger.warning(
                 "Skipping user config %s",
                 {
                     "username": config["username"],
                     "slug": slug,
-                    "reason": "wrong slug for username",
+                    "reason": "wrong slug for user ID",
                 },
             )
             continue

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -57,19 +57,20 @@ class Connection:
                 {"id": "www", "name": "Wikidot", "secure": 1}
             )
         # Always add the configuration wiki, if it's not already present
-        if not any(
-            True
-            for wiki in self.supported_wikis
-            if wiki["id"] == config["config_wiki"]
-        ):
-            self.supported_wikis.append(
-                {
-                    "id": config["config_wiki"],
-                    "name": "Configuration",
-                    # Assume it's unsecure as that's most common
-                    "secure": 0,
-                }
+        try:
+            self.config_wiki = next(
+                wiki
+                for wiki in self.supported_wikis
+                if wiki["id"] == config["config_wiki"]
             )
+        except StopIteration:
+            self.config_wiki = {
+                "id": config["config_wiki"],
+                "name": "Configuration",
+                # Assume it's unsecure as that's most common
+                "secure": 0,
+            }
+            self.supported_wikis.append(self.config_wiki)
 
     def post(self, url, **kwargs):
         """Make a POST request."""


### PR DESCRIPTION
I'd planned to use Wikidot's user profile's feature to ease moderation of the config site. However, after investigation, I discovered that these pages would be registered as having been created by 'Wikidot' (i.e. by no user), leading me unable to determine if the page had actually been created by the correct user; additionally, I would not be able to restrict editing of that page to that user only.

Instead I'm left with the brute-force option that I was dreading: systematic moderation.

I currently have the site set up so that any user can create any page in the `notify:` category, but only the user who created a page can edit it. Therefore, the only possible attack vector is malicious page creation - either in bulk, or targeting a specific user to cause them to be unable to configure their notifications.

The solution is the same for both cases: I need to delete any improper pages. 'Improper' is defined as any page where the page slug is not equal to the ID of the user who is credited with creating it. I will silently delete any such pages.


- [x] Detect pages with incongruent slugs
- [x] Rename those pages to a unique string prior to deletion
- [x] Delete those pages
- [x] Store user configs at pages named for the user's ID, not their name (as their name is mutable, and this feature would cause those pages to be deleted if they change their name)
- [x] Move existing configs to the correct location
- [x] Reflect this change in the code
- [x] Reflect this change in the database
  - I don't think there are any changes to be made? I already track user ID - I just need to make sure I actually use that instead of the username, wherever possible
- [x] Add a migration, if there are any changes to the database
- [x] Split 'mass rename' and 'mass delete into separate things, and run them for each set of articles splits between two runs (so that wikidot *definitely* has time to execute the rename)