### PR TITLE
Fix automatic sub retrieval for user config construction

### DIFF
--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from contextlib import contextmanager
+from itertools import chain
 from typing import Iterable, Iterator, List, Tuple, cast
 
 import pymysql
@@ -302,14 +303,16 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
             ]
             user_config["auto_subs"] = [
                 cast(Subscription, dict(row))
-                for row in self.execute_named(
-                    "get_auto_sub_posts_for_user",
-                    {"user_id": user_config["user_id"]},
-                ).fetchall()
-                + self.execute_named(
-                    "get_auto_sub_threads_for_user",
-                    {"user_id": user_config["user_id"]},
-                ).fetchall()
+                for row in chain(
+                    self.execute_named(
+                        "get_auto_sub_posts_for_user",
+                        {"user_id": user_config["user_id"]},
+                    ).fetchall(),
+                    self.execute_named(
+                        "get_auto_sub_threads_for_user",
+                        {"user_id": user_config["user_id"]},
+                    ).fetchall(),
+                )
             ]
         return user_configs
 


### PR DESCRIPTION
Was getting a persistent error on remote that I couldn't reproduce locally:

```
[ERROR] TypeError: can only concatenate list (not "tuple") to list
Traceback (most recent call last):
  File "/opt/python/lib/python3.8/site-packages/codeguru_profiler_agent/aws_lambda/profiler_decorator.py", line 52, in profiler_decorate
    return function(event, context)
  File "/opt/python/lib/python3.8/site-packages/codeguru_profiler_agent/aws_lambda/lambda_handler.py", line 51, in call_handler
    return handler_function(event, context)
  File "/var/task/lambda_function.py", line 38, in lambda_handler
    main(
  File "/var/task/notifier/main.py", line 54, in main
    notify(config, auth, channels, database)
  File "/var/task/notifier/notify.py", line 110, in notify
    notify_active_channels(
  File "/var/task/notifier/notify.py", line 142, in notify_active_channels
    notify_channel(
  File "/var/task/notifier/notify.py", line 164, in notify_channel
    user_configs = database.get_user_configs(channel)
  File "/var/task/notifier/database/drivers/mysql.py", line 305, in get_user_configs
    for row in self.execute_named(
```

This comes from the list concatenation of auto thread posts. Just naively chaining instead should fix this issue.