### PR TITLE
User config error tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ page:
 document.querySelector("[name=field-frequency]").value = "test"
 ```
 
+To restrict which wikis posts will be downloaded from, add `--limit-wikis
+[list]`.
+
 ## Remote deployment
 
 The notifier service is not intended to be executed locally or even to be

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -1,24 +1,26 @@
 import argparse
 import logging
-from typing import List, Optional, Tuple
 
 from notifier.config.local import read_local_auth, read_local_config
 from notifier.main import main
 from notifier.notify import notification_channels
-from notifier.types import AuthConfig, LocalConfig
 
 logger = logging.getLogger(__name__)
 
 
 def cli():
     """Run main procedure as a command-line tool."""
-    config, auth, execute_now, limit_wikis = read_command_line_arguments()
-    main(config, auth, execute_now, limit_wikis)
+    args = read_command_line_arguments()
+    main(
+        read_local_config(args.config),
+        read_local_auth(args.auth),
+        args.execute_now,
+        args.limit_wikis,
+        args.force_initial_search_timestamp,
+    )
 
 
-def read_command_line_arguments() -> Tuple[
-    LocalConfig, AuthConfig, Optional[List[str]], Optional[List[str]]
-]:
+def read_command_line_arguments():
     """Extracts from the command line the config file and auth file."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -42,9 +44,10 @@ def read_command_line_arguments() -> Tuple[
         subset of the wiki IDs listed in the remote configuration.""",
         nargs="+",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--force-initial-search-timestamp",
+        type=int,
+        help="""The lower timestamp to use when searching for posts.""",
+    )
 
-    config_file = read_local_config(args.config)
-    auth_file = read_local_auth(args.auth)
-
-    return config_file, auth_file, args.execute_now, args.limit_wikis
+    return parser.parse_args()

--- a/notifier/cli.py
+++ b/notifier/cli.py
@@ -12,12 +12,12 @@ logger = logging.getLogger(__name__)
 
 def cli():
     """Run main procedure as a command-line tool."""
-    config, auth, execute_now = read_command_line_arguments()
-    main(config, auth, execute_now)
+    config, auth, execute_now, limit_wikis = read_command_line_arguments()
+    main(config, auth, execute_now, limit_wikis)
 
 
 def read_command_line_arguments() -> Tuple[
-    LocalConfig, AuthConfig, Optional[List[str]]
+    LocalConfig, AuthConfig, Optional[List[str]], Optional[List[str]]
 ]:
     """Extracts from the command line the config file and auth file."""
     parser = argparse.ArgumentParser()
@@ -35,9 +35,16 @@ def read_command_line_arguments() -> Tuple[
         nargs="*",
         choices=notification_channels.keys(),
     )
+    parser.add_argument(
+        "--limit-wikis",
+        type=str,
+        help="""A set of wiki IDs to download new posts from. Must be a
+        subset of the wiki IDs listed in the remote configuration.""",
+        nargs="+",
+    )
     args = parser.parse_args()
 
     config_file = read_local_config(args.config)
     auth_file = read_local_auth(args.auth)
 
-    return config_file, auth_file, args.execute_now
+    return config_file, auth_file, args.execute_now, args.limit_wikis

--- a/notifier/config/user.py
+++ b/notifier/config/user.py
@@ -28,6 +28,7 @@ frequency = "%%form_raw{frequency}%%"
 language = "%%form_raw{language}%%"
 delivery = "%%form_raw{method}%%"
 user_base_notified = """%%created_at%%"""
+tags = """%%tags%%"""
 subscriptions = """
 %%form_data{subscriptions}%%"""
 unsubscriptions = """
@@ -124,6 +125,8 @@ def parse_raw_user_config(
     # Parse page date to approximate timestamp and coerce to int
     # TODO Move hardcoded date to config
     config["user_base_notified"] = max(user_timestamp or 0, 1627277777)
+    assert "tags" in config
+    assert isinstance(config["tags"], str)
     config["subscriptions"] = parse_subscriptions(
         config.get("subscriptions", ""), 1
     )

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -329,6 +329,7 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
                         "frequency": user_config["frequency"],
                         "language": user_config["language"],
                         "delivery": user_config["delivery"],
+                        "tags": user_config["tags"],
                     },
                     cursor,
                 )

--- a/notifier/database/migrations/002-track-user-config-tags.down.sql
+++ b/notifier/database/migrations/002-track-user-config-tags.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  user_config
+DROP COLUMN
+  tags;

--- a/notifier/database/migrations/002-track-user-config-tags.up.sql
+++ b/notifier/database/migrations/002-track-user-config-tags.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+  user_config
+ADD COLUMN
+  tags VARCHAR(2000) NOT NULL;
+
+UPDATE
+  user_config
+SET
+  tags = "";

--- a/notifier/database/queries/get_user_configs_for_frequency.sql
+++ b/notifier/database/queries/get_user_configs_for_frequency.sql
@@ -4,6 +4,7 @@ SELECT
   user_config.frequency AS frequency,
   user_config.language AS language,
   user_config.delivery AS delivery,
+  user_config.tags AS tags,
   user_last_notified.notified_timestamp AS last_notified_timestamp
 FROM
   user_config

--- a/notifier/database/queries/store_user_config.sql
+++ b/notifier/database/queries/store_user_config.sql
@@ -1,5 +1,19 @@
 INSERT INTO
   user_config
-  (user_id, username, frequency, language, delivery)
+  (
+    user_id,
+    username,
+    frequency,
+    language,
+    delivery,
+    tags
+  )
 VALUES
-  (%(user_id)s, %(username)s, %(frequency)s, %(language)s, %(delivery)s)
+  (
+    %(user_id)s,
+    %(username)s,
+    %(frequency)s,
+    %(language)s,
+    %(delivery)s,
+    %(tags)s
+  )

--- a/notifier/main.py
+++ b/notifier/main.py
@@ -16,7 +16,12 @@ from notifier.types import AuthConfig, LocalConfig
 logger = logging.getLogger(__name__)
 
 
-def main(config: LocalConfig, auth: AuthConfig, execute_now: List[str] = None):
+def main(
+    config: LocalConfig,
+    auth: AuthConfig,
+    execute_now: List[str] = None,
+    limit_wikis: List[str] = None,
+):
     """Main executor, supposed to be called via command line."""
 
     logging.info("The current time is %s", now)
@@ -38,7 +43,9 @@ def main(config: LocalConfig, auth: AuthConfig, execute_now: List[str] = None):
 
         # Schedule the task
         scheduler.add_job(
-            lambda: notify(config, auth, pick_channels_to_notify(), database),
+            lambda: notify(
+                config, auth, pick_channels_to_notify(), database, limit_wikis
+            ),
             CronTrigger.from_crontab(notification_channels["hourly"]),
         )
 
@@ -51,6 +58,6 @@ def main(config: LocalConfig, auth: AuthConfig, execute_now: List[str] = None):
         channels = pick_channels_to_notify(execute_now)
 
         # Run immediately and once only
-        notify(config, auth, channels, database)
+        notify(config, auth, channels, database, limit_wikis)
 
         print("Finished")

--- a/notifier/main.py
+++ b/notifier/main.py
@@ -21,6 +21,7 @@ def main(
     auth: AuthConfig,
     execute_now: List[str] = None,
     limit_wikis: List[str] = None,
+    force_initial_search_timestamp: int = None,
 ):
     """Main executor, supposed to be called via command line."""
 
@@ -47,7 +48,12 @@ def main(
         # Schedule the task
         scheduler.add_job(
             lambda: notify(
-                config, auth, pick_channels_to_notify(), database, limit_wikis
+                config,
+                auth,
+                pick_channels_to_notify(),
+                database,
+                limit_wikis,
+                force_initial_search_timestamp,
             ),
             CronTrigger.from_crontab(notification_channels["hourly"]),
         )
@@ -61,6 +67,13 @@ def main(
         channels = pick_channels_to_notify(execute_now)
 
         # Run immediately and once only
-        notify(config, auth, channels, database, limit_wikis)
+        notify(
+            config,
+            auth,
+            channels,
+            database,
+            limit_wikis,
+            force_initial_search_timestamp,
+        )
 
         print("Finished")

--- a/notifier/main.py
+++ b/notifier/main.py
@@ -24,7 +24,7 @@ def main(
 ):
     """Main executor, supposed to be called via command line."""
 
-    logging.info("The current time is %s", now)
+    logger.info("The current time is %s", now)
 
     # Database stores forum posts and caches subscriptions
     DatabaseDriver = resolve_driver_from_config(config["database"]["driver"])
@@ -34,6 +34,9 @@ def main(
         username=auth["mysql_username"],
         password=auth["mysql_password"],
     )
+
+    if limit_wikis is not None:
+        logger.info("Wikis will be limited to %s", limit_wikis)
 
     if execute_now is None:
         logger.info("Starting in scheduled mode")

--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -21,7 +21,11 @@ def get_new_posts(
     limit_wikis: List[str] = None,
 ):
     """For each configured wiki, retrieve and store new posts."""
-    for wiki in database.get_supported_wikis():
+    wikis = database.get_supported_wikis()
+    if limit_wikis is not None:
+        wikis = [wiki for wiki in wikis if wiki["id"] in limit_wikis]
+    logger.info("Downloading posts from wikis %s", wikis)
+    for wiki in wikis:
         if limit_wikis is not None and wiki["id"] in limit_wikis:
             continue
         logger.info("Getting new posts %s", {"for wiki_id": wiki["id"]})

--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -15,9 +15,15 @@ logger = logging.getLogger(__name__)
 new_posts_rss = "http://{}.wikidot.com/feed/forum/posts.xml"
 
 
-def get_new_posts(database: BaseDatabaseDriver, connection: Connection):
+def get_new_posts(
+    database: BaseDatabaseDriver,
+    connection: Connection,
+    limit_wikis: List[str] = None,
+):
     """For each configured wiki, retrieve and store new posts."""
     for wiki in database.get_supported_wikis():
+        if limit_wikis is not None and wiki["id"] in limit_wikis:
+            continue
         logger.info("Getting new posts %s", {"for wiki_id": wiki["id"]})
         try:
             fetch_posts_with_context(wiki["id"], database, connection)

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -142,6 +142,7 @@ def notify_active_channels(
         notify_channel(
             channel,
             current_timestamp,
+            config=config,
             database=database,
             connection=connection,
             digester=digester,
@@ -153,6 +154,7 @@ def notify_channel(
     channel: str,
     current_timestamp: int,
     *,
+    config: LocalConfig,
     database: BaseDatabaseDriver,
     connection: Connection,
     digester: Digester,
@@ -175,6 +177,7 @@ def notify_channel(
                 user,
                 channel,
                 current_timestamp,
+                config=config,
                 database=database,
                 connection=connection,
                 digester=digester,
@@ -215,6 +218,7 @@ def notify_user(
     channel: str,
     current_timestamp: int,
     *,
+    config: LocalConfig,
     database: BaseDatabaseDriver,
     connection: Connection,
     digester: Digester,
@@ -316,7 +320,16 @@ def notify_user(
                     "reason": "not a back-contact",
                 },
             )
-            # They'll have to fix this themselves
+            # They'll have to fix this themselves - inform them
+            inform_tag = "not-a-back-contact"
+            if inform_tag not in user["tags"]:
+                connection.set_tags(
+                    config["config_wiki"],
+                    ":".join(
+                        [config["user_config_category"], str(user["user_id"])]
+                    ),
+                    " ".join([user["tags"], inform_tag]),
+                )
             return False
         logger.debug(
             "Sending notification %s",

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -306,6 +306,7 @@ def notify_user(
         else:
             logger.debug("Using cached email contacts")
 
+        email_inform_tag = "not-a-back-contact"
         try:
             address = addresses[user["username"]]
         except KeyError:
@@ -321,16 +322,24 @@ def notify_user(
                 },
             )
             # They'll have to fix this themselves - inform them
-            inform_tag = "not-a-back-contact"
-            if inform_tag not in user["tags"]:
+            if email_inform_tag not in user["tags"]:
                 connection.set_tags(
                     config["config_wiki"],
                     ":".join(
                         [config["user_config_category"], str(user["user_id"])]
                     ),
-                    " ".join([user["tags"], inform_tag]),
+                    " ".join([user["tags"], email_inform_tag]),
                 )
             return False
+        if email_inform_tag in user["tags"]:
+            # This user has fixed the above issue, so remove the tag
+            connection.set_tags(
+                config["config_wiki"],
+                ":".join(
+                    [config["user_config_category"], str(user["user_id"])]
+                ),
+                user["tags"].replace(email_inform_tag, ""),
+            )
         logger.debug(
             "Sending notification %s",
             {"user": user["username"], "via": "email", "channel": channel},

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -381,13 +381,12 @@ def notify_user(
         },
     )
 
-    # If the method was PM and the delivery was successful, remove the
-    # restricted inbox tag
-    if user["delivery"] == "pm" and pm_inform_tag in user["tags"]:
+    # If the delivery was successful, remove any error tags
+    if user["tags"] != "":
         connection.set_tags(
             config["config_wiki"],
             ":".join([config["user_config_category"], str(user["user_id"])]),
-            user["tags"].replace(pm_inform_tag, ""),
+            "",
         )
 
     return True

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -73,6 +73,7 @@ def notify(
     auth: AuthConfig,
     active_channels: List[str],
     database: BaseDatabaseDriver,
+    limit_wikis: List[str] = None,
 ):
     """Main task executor. Should be called as often as the most frequent
     notification digest.
@@ -98,7 +99,7 @@ def notify(
     connection = Connection(config, database.get_supported_wikis())
 
     logger.info("Getting new posts...")
-    get_new_posts(database, connection)
+    get_new_posts(database, connection, limit_wikis)
 
     # Record the 'current' timestamp immediately after downloading posts
     current_timestamp = int(time.time())

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -95,6 +95,7 @@ class RawUserConfig(TypedDict):
     language: str
     delivery: DeliveryMethod
     user_base_notified: int
+    tags: str
     subscriptions: List[Subscription]
     unsubscriptions: List[Subscription]
 

--- a/notifier/types.py
+++ b/notifier/types.py
@@ -109,6 +109,7 @@ class CachedUserConfig(TypedDict):
     language: str
     delivery: DeliveryMethod
     last_notified_timestamp: int
+    tags: str
     manual_subs: List[Subscription]
     auto_subs: List[Subscription]
 

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -38,6 +38,11 @@ class ThreadNotExists(Exception):
     exist before) that it was deleted."""
 
 
+class RestrictedInbox(Exception):
+    """Indicates that a user could not receive a Wikidot PM because their
+    inbox is restricted."""
+
+
 class Connection:
     """Connection to Wikidot facilitating communications with it."""
 
@@ -114,6 +119,12 @@ class Connection:
             raise
         if response["status"] == "no_thread":
             raise ThreadNotExists
+        if (
+            response["status"] == "no_permission"
+            and response["message"]
+            == "This user wishes to receive messages only from selected users."
+        ):
+            raise RestrictedInbox
         if response["status"] != "ok":
             logger.error(
                 "Bad response from Wikidot %s",

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -457,6 +457,6 @@ class Connection:
             "Empty",
             action="WikiPageAction",
             event="saveTags",
-            page_id=str(page_id),
-            tags=tags,
+            pageId=str(page_id),
+            tags=tags.strip(),
         )

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -422,3 +422,30 @@ class Connection:
             event="deletePage",
             page_id=str(page_id),
         )
+
+    def set_tags(self, wiki_id: str, slug: str, tags: str) -> None:
+        """Sets the tags on a page.
+
+        Overrides all previous tags, so if amending a page's tags, be sure
+        to have already observed them.
+
+        Connection needs to be logged in.
+        """
+        page_id = self.get_page_id(wiki_id, slug)
+        logger.debug(
+            "Setting page tags %s",
+            {
+                "tags": tags,
+                "on slug": slug,
+                "with id": page_id,
+                "on wiki": wiki_id,
+            },
+        )
+        self.module(
+            wiki_id,
+            "Empty",
+            action="WikiPageAction",
+            event="saveTags",
+            page_id=str(page_id),
+            tags=tags,
+        )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -53,10 +53,11 @@ def sample_database(
             "language",
             "delivery",
             "user_base_notified",
+            "tags",
             "subscriptions",
             "unsubscriptions",
         ],
-        [("1", "MyUser", "hourly", "en", "pm", 1, subs, unsubs)],
+        [("1", "MyUser", "hourly", "en", "pm", 1, "", subs, unsubs)],
     )
     sample_wikis: List[SupportedWikiConfig] = construct(
         ["id", "name", "secure"], [("my-wiki", "My Wiki", 1)]

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -2,10 +2,19 @@ from pathlib import Path
 
 import pytest
 
-from notifier.digest import Digester, make_wikis_digest, pluralise, process_long_strings
+from notifier.digest import (
+    Digester,
+    make_wikis_digest,
+    pluralise,
+    process_long_strings,
+)
 from notifier.formatter import convert_syntax
 from notifier.overrides import apply_overrides, override_applies_to_post
-from notifier.types import CachedUserConfig, GlobalOverridesConfig, NewPostsInfo
+from notifier.types import (
+    CachedUserConfig,
+    GlobalOverridesConfig,
+    NewPostsInfo,
+)
 
 
 @pytest.fixture(scope="module")
@@ -18,6 +27,7 @@ def fake_user() -> CachedUserConfig:
         "language": "en",
         "delivery": "pm",
         "last_notified_timestamp": 0,
+        "tags": "",
         "manual_subs": [],
         "auto_subs": [],
     }


### PR DESCRIPTION
Configuration errors normally result in the user not being able to be notified of anything. Not being able to be notified means I'm unable to automatically notifiy them that they can't automatically be notified, so the user is never prompted to fix their config.

What I can do instead is edit their user config page to add a message explaining what the problem is and how to fix it, without any intervention from me. I can do this easily without compromising the data form by adding tags to the page. notifier can add these tags when it detects the error, not attempt to notify the user for as long as they're there, and remove the tags when the error is resolved.

Tags implemented so far:

* `restricted-inbox` - notifier failed to send a PM because the user has a restricted inbox.
* `not-a-back-contact` - notifier failed to send an email because the user did not add Notifier as a Wikidot contact.

- [x] Get tags from the remote config
- [x] Cache page tags in the database
- [x] Add functionality for setting page tags
- [x] Detect error situations, and add tags
   * restricted inbox: error when wikidot returns a certain error when attempting to send a pm (check)
   * not a back contact: error when user not in back-contacts list AND method is email
- [x] Detect error resolutions, and remove tags
  * restricted inbox: can only be detected by attempting to message the user OR if method changes to email
  * not a back contact: can be detected by looking at the back-contacts list OR if method changes to pm
- [x] Do not attempt to notify any users with errors
- [x] Update error descriptions as presented to the user with accurate indications of how to fix the error, and of when the error message will be automatically removed
  * I can remove both tags when I notify the user, so that seems easiest for consolidation
- [x] Add a testing utility that allows me to restrict which sites to get new posts from