### PR TITLE
Add option to be notified every 8 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ must be run during the first minute of an hour to match any channels.
 To activate a manually-chosen channel or set of channels immediately and
 once only, even at a time when such channel would not normally be
 activated, add the `--execute-now` switch followed by any of `hourly`,
-`daily`, `weekly`, `monthly` and `test`.
+`8hourly`, `daily`, `weekly`, `monthly` and `test`.
 
 The `test` channel will never be activated during normal usage. Note that
 the user config setting for the `test` channel is hidden, and can be

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -114,6 +114,7 @@ class Digester:
         )
         frequency = {
             "hourly": lexicon["frequency_hourly"],
+            "8hourly": lexicon["frequency_8hourly"],
             "daily": lexicon["frequency_daily"],
             "weekly": lexicon["frequency_weekly"],
             "monthly": lexicon["frequency_monthly"],

--- a/notifier/lang.toml
+++ b/notifier/lang.toml
@@ -72,6 +72,7 @@ outro = """
 
 [en]
 frequency_hourly = "hourly"
+frequency_8hourly = "every-8-hours"
 frequency_daily = "daily"
 frequency_weekly = "weekly"
 frequency_monthly = "monthly"
@@ -119,6 +120,7 @@ untitled_post_title = "(untitled post)"
 
 [vi]
 frequency_hourly = "hàng giờ"
+frequency_8hourly = "8 giờ một lần"
 frequency_daily = "hàng ngày"
 frequency_weekly = "hàng tuần"
 frequency_monthly = "hàng tháng"
@@ -168,6 +170,7 @@ link_info_learning = "{link_site}#learning"
 link_info_automatic = "{link_site}#auto"
 
 frequency_hourly = "de la dernière heure"
+frequency_8hourly = "dans les 8 dernières heures"
 frequency_daily = "journalier"
 frequency_weekly = "hebdomadaire"
 frequency_monthly = "mensuel"
@@ -203,6 +206,7 @@ untitled_post_title = "(message sans titre)"
 
 [es]
 frequency_hourly = "de cada hora"
+frequency_8hourly = "de cada 8 horas"
 frequency_daily = "diario"
 frequency_weekly = "semanal"
 frequency_monthly = "mensual"
@@ -247,6 +251,7 @@ untitled_post_title = "(publicación sin título)"
 
 [ja]
 frequency_hourly = "一時間ごと"
+frequency_8hourly = "八時間ごと"
 frequency_daily = "一日ごと"
 frequency_weekly = "一週間ごと"
 frequency_monthly = "ひと月ごと"
@@ -280,6 +285,7 @@ untitled_post_title = "(無題のポスト)"
 
 [zh]
 frequency_hourly = "每小时"
+frequency_8hourly = "每8小时"
 frequency_daily = "每日"
 frequency_weekly = "每周"
 frequency_monthly = "每月"

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # frequency.
 notification_channels = {
     "hourly": "0 * * * *",
+    "8hourly": "0 */3 * * *",
     "daily": "0 0 * * *",
     "weekly": "0 0 * * 0",
     "monthly": "0 0 1 * *",


### PR DESCRIPTION
[Requested by Wikidot user LORDXVNV](https://scp-wiki.wikidot.com/forum/t-14209085/forum-notifications-service#post-5116543):

> I do have a feature request, if possible: would it be viable to add 4/6/8 hour notification windows? I've found 1 hour to overfill my inbox but 24 hours to be so long that there's a good chance I've seen all the comments already.

Canonising the ID of this option as `8hourly`.

- [x] Add the option to the user config form