### PR TITLE
Upgrade to MySQL 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,7 @@ See [docs/auth.md](/docs/auth.md) for more information and instructions.
 
 ## Database setup
 
-For local development and testing, notifier requires a database to be set
-up on a version of MySQL that is compatible with Amazon Aurora Serverless
-v1.
-
-See [docs/database.md](/docs/database.md) for more information and
-instructions.
+For local development and testing, notifier requires a MySQL database. See [docs/database.md](/docs/database.md) for more information and instructions.
 
 ## Local execution
 
@@ -138,7 +133,7 @@ poetry run mypy notifier
 
 ### Testing locally
 
-To run tests locally:
+To run tests directly on your machine:
 
 ```shell
 poetry run pytest --notifier-config path_to_config_file --notifier-auth path_to_auth_file

--- a/config/auth.compose.toml
+++ b/config/auth.compose.toml
@@ -1,5 +1,5 @@
 wikidot_password = ""
 gmail_password = ""
 mysql_host = "database"
-mysql_username = "root"
-mysql_password = "root"
+mysql_username = "notifier"
+mysql_password = "notifier"

--- a/config/lang.toml
+++ b/config/lang.toml
@@ -5,6 +5,8 @@ link_unsubscribe = "{link_site}/faq#stop"
 link_info_learning = "{link_site}/faq#learning"
 link_info_automatic = "{link_site}/faq#auto"
 
+frequency_test = "< TEST (which you have opted into) >"
+
 body = """
 {intro}
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,7 +26,7 @@ services:
       MYSQL_PASSWORD: 'notifier'
       MYSQL_ROOT_HOST: '0.0.0.0'
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-proot"]
+      test: ["CMD", "mysqladmin" ,"status", "-uroot", "-proot"]
       interval: 3s
       timeout: 3s
       retries: 10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,15 +15,16 @@ services:
         condition: service_healthy
 
   database:
-    image: mysql:5.7.4
-    command: mysqld --datadir=/var/lib/mysql --user=mysql --init-file /data/application/init.sql
-    volumes:
-      - ./tests/init.sql:/data/application/init.sql
+    image: mysql:8.0.33
+    command: --default-authentication-plugin=mysql_native_password
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD-root}
-      - MYSQL_DATABASE=${MYSQL_DATABASE-wikidot_notifier_test}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD-root}
+      MYSQL_DATABASE: ${MYSQL_DATABASE-wikidot_notifier_test}
+      MYSQL_USER: 'notifier'
+      MYSQL_PASSWORD: 'notifier'
+      MYSQL_ROOT_HOST: '0.0.0.0'
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-proot"]
       interval: 3s

--- a/docs/database.md
+++ b/docs/database.md
@@ -3,29 +3,15 @@
 notifier uses MySQL. It and the database need to be set up before it can
 operate, or before tests can be run.
 
-This document assumes some familiarity with
-[Docker](https://www.docker.com/).
+notifier uses the latest stable release of MySQL as of the time of writing, 8.0.33.
+
+Running in the cloud, Docker is no longer needed and introduces an unnecessary performance overhead for production. Spin up a dedicated server of some kind and install MySQL directly onto it.
 
 ## Setting up MySQL
 
-notifier is designed to use [Amazon Aurora Serverless
-v1](https://aws.amazon.com/rds/aurora/serverless/) during production. The
-latest version of MySQL supported by Aurora Serverless is 5.6.10 (for
-reference, the latest version of MySQL at the time of writing is 8.0.26).
-For this reason, a compatible version of MySQL is needed for local
-development.
+### Locally
 
-(Note 2023-02-25: The database has been upgraded to MySQL 5.7 as part of a
-mandatory Aurora engine upgrade.)
-
-[Docker](https://www.docker.com/) is used for pinning the MySQL version,
-and to avoid this version conflicting with any MySQL already installed on
-your system.
-
-The earliest version of MySQL 5.6 available in the official MySQL Docker
-registry is 5.6.17; therefore, although it's not ideal, I recommend running
-tests locally against this version of MySQL. This is also the version that
-[I use in CI](/.github/workflows/tests.yml).
+Running on your local machine, I advise running MySQL in a [Docker](https://www.docker.com/) container. This is to avoid this version conflicting with any MySQL already installed on your system, and to make it easy to pin a required version.
 
 Create the MySQL Server container:
 
@@ -62,6 +48,14 @@ docker inspect \
 ```
 
 Once inside the database server, you can create the database.
+
+### In the cloud
+
+Left as an exercise for the reader.
+
+I recommend installing from source if possible to get the latest version.
+
+If deploying the database as an AWS EC2 on a private VPS, you can cheat and get internet connectivity to download the necessary files by temporarily assigning it an Elastic IP. Just remember to dissociate _and release_ it afterwards.
 
 ## Creating the database
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -16,10 +16,7 @@ Running on your local machine, I advise running MySQL in a [Docker](https://www.
 Create the MySQL Server container:
 
 ```shell
-docker create --name notifier_mysql \
-  -p 3306:3306 \
-  -e MYSQL_ROOT_PASSWORD=root \
-  mysql:5.7.4
+docker create --name notifier_mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root mysql:8.0.33
 ```
 
 For an ephemeral, development-only, containerised MySQL installation I'm
@@ -32,7 +29,7 @@ Start the container:
 docker start notifier_mysql
 ```
 
-To access the database using the MySQL client:
+To access the database from the local command line using the MySQL client, use `127.0.0.1` the local loopback interface (`localhost` doesn't work in my experience):
 
 ```shell
 mysql -h127.0.0.1 -uroot -proot
@@ -42,12 +39,17 @@ If `127.0.0.1` doesn't work you may need to find the IP of the Docker
 container and use that instead:
 
 ```shell
-docker inspect \
-  -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
-  notifier_mysql
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' notifier_mysql
 ```
 
 Once inside the database server, you can create the database.
+
+If you want to connect to the database from inside a _different_ Docker container (e.g. a container running the main notifier Python application), '`127.0.0.1`' pinged from inside that container will refer to itself, not to the database container. You will need to connect the two containers via a Docker network. There are plenty of methods of doing that but the easiest in my opinion is adding a `--network` flag to the command used to launch the 2nd container, instructing it to use the database's network stack:
+
+```shell
+docker run --network=container:notifier_mysql ...
+```
+
 
 ### In the cloud
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,15 +173,15 @@ Create a second new security group:
 
 ## Creating the database
 
-As discussed in [docs/database.md](/docs/database.md), notifier is designed
+The database for notifier was originally (2021-07-22) designed to run on Amazon Aurora Serverless v1, and the original setup instructions remain below. As of 2023-03-19, the database no longer runs on Aurora Serverless v1, it now runs on an EC2. This is considerably cheaper.
+
+### On Aurora Serverless v1
+
+As discussed in [docs/database.md](/docs/database.md), notifier ~~is~~ was designed
 to use Amazon Aurora Serverless v1. notifier only runs once an hour, so it
 doesn't make sense to pay for provisioning an always-available database for
 the 55 minutes per hour that it's not in use. The notifier codebase is
 compatible with MySQL 5.6.10a.
-
-As of 2023-03-19, the database no longer runs on Aurora Serverless v1, it now runs on an EC2. This is considerably cheaper.
-
-### On Aurora Serverless v1
 
 (Note 2023-02-25: The database has been upgraded to MySQL 5.7 as part of a
 mandatory Aurora engine upgrade.)
@@ -190,7 +190,7 @@ In the RDS section of the console, create a new database with the following
 settings:
 
 - Use the *Standard create* creation method. Choose the Amazon Aurora
-  database engine, with MySQL 5.6.10 compatibility. Set the capacity type
+  database engine, with MySQL 5.7 compatibility. Set the capacity type
   to serverless.
 - Give a name to the database cluster &mdash; I named mine
   `wikidotnotifierbdcluster` (it normalises to lowercase).
@@ -217,7 +217,9 @@ databases.
 
 ### On an EC2
 
-Aurora Serverless v1 is overpriced and it may be cheaper to run the database on an EC2 instance.
+It is cheaper to run the database as an EC2 instance rather than using an Aurora RDS database, even if it is 'serverless'.
+
+(Note 2023-06-11: The database has been upgraded to MySQL 8.0.33 and as of the time of writing is set up on a `c6g.medium` instance, as mentioned as a possibility below. Original setup instructions for MySQL 5.7 and `t3.nano` are retained below for posterity.)
 
 In the EC2 section of the console:
 
@@ -294,7 +296,7 @@ hostname of the DB cluster and `<user>` with the cluster's admin username
 mysql -h<HOST> -u<user> -p
 ```
 
-Once connected, confirm that the MySQL version is 5.6.10.
+Once connected, confirm the MySQL version.
 
 Use the MySQL client to set up the database and user identity for the
 notifier service as instructed in [docs/database.md](/docs/database.md):
@@ -458,7 +460,6 @@ There are three ways of enabling a Lambda in a VPC to access the internet,
   - If you choose `t3a.nano` as the instance type, which at the time of
     writing is charged at $0.0047 per hour,<sup>6</sup> this will cost
     roughly $3.50 per month.
-  - Congratulations, your serverless solution is no longer serverless!
 - You can assign Elastic IPs to the Lambda's network interfaces, which
   enables them to access the internet.<sup>7</sup> I don't understand how
   or why this works, but it does. AWS does not recommend this solution
@@ -471,6 +472,7 @@ There are three ways of enabling a Lambda in a VPC to access the internet,
     have already alleviated this concern by setting the Lambda's
     concurrency limit to 1 &mdash; it *should* never need additional
     interfaces.
+    - At the time of writing this bullet point (2023-06-11, almost 2 years after writing the above on 2021-09-18), the above solution has needed maintenance exactly 0 times.
   - To implement this solution:
     - Find *Network interfaces* in the EC2 console. Locate any ENIs that
       are associated with the `WikidotNotifierAccessToInternet` security

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -320,6 +320,7 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
         return user_configs
 
     def get_notifiable_users(self, frequency: str) -> List[str]:
+        self.execute_named("cache_post_context")
         user_ids = [
             cast(str, row["user_id"])
             for row in self.execute_named(

--- a/notifier/database/migrations/001-track-first-post-id-per-thread.up.sql
+++ b/notifier/database/migrations/001-track-first-post-id-per-thread.up.sql
@@ -15,7 +15,7 @@ FROM
     SELECT first_post.id FROM
       post AS first_post
     GROUP BY
-      first_post.thread_id
+      first_post.thread_id, first_post.id
     HAVING
       MIN(first_post.posted_timestamp)
       AND first_post.thread_id = thread.id

--- a/notifier/database/queries/cache_post_context.sql
+++ b/notifier/database/queries/cache_post_context.sql
@@ -1,0 +1,24 @@
+CREATE TEMPORARY TABLE IF NOT EXISTS post_with_context
+WITH cte AS (
+  SELECT
+    post.user_id AS post_user_id,
+    post.posted_timestamp AS post_posted_timestamp,
+    parent_post.id AS parent_post_id,
+    parent_post.user_id AS parent_post_user_id,
+    thread.id AS thread_id,
+    first_post_in_thread.user_id AS first_post_in_thread_user_id
+  FROM
+    post
+    INNER JOIN
+    thread ON thread.id = post.thread_id
+    INNER JOIN
+    thread_first_post ON thread_first_post.thread_id = thread.id
+    INNER JOIN
+    post AS first_post_in_thread ON first_post_in_thread.id = thread_first_post.post_id
+    LEFT JOIN
+    post AS parent_post ON parent_post.id = post.parent_post_id
+  WHERE
+    -- Remove deleted threads/posts
+    thread.is_deleted = 0 AND post.is_deleted = 0
+)
+SELECT * FROM cte

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -118,7 +118,8 @@ class Digester:
             "daily": lexicon["frequency_daily"],
             "weekly": lexicon["frequency_weekly"],
             "monthly": lexicon["frequency_monthly"],
-        }.get(user["frequency"], "")
+            "test": lexicon["frequency_test"],
+        }.get(user["frequency"], "undefined")
         intro = lexicon["intro"].format(
             frequency=frequency,
             link_site=lexicon["link_site"],

--- a/notifier/main.py
+++ b/notifier/main.py
@@ -10,7 +10,7 @@ from notifier.notify import (
     notify,
     pick_channels_to_notify,
 )
-from notifier.timing import now, override_current_time
+from notifier.timing import delay, now, override_current_time
 from notifier.types import AuthConfig, LocalConfig
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,14 @@ def main(
     if force_current_time is not None:
         override_current_time(force_current_time)
         logger.info("The current time is %s", now)
+
+    if dry_run:
+        logger.info("Performing a dry run - no notifications will be sent")
+    else:
+        logger.info(
+            "Not performing a dry run - cancel within 5s if not intended"
+        )
+        delay()
 
     # Database stores forum posts and caches subscriptions
     DatabaseDriver = resolve_driver_from_config(config["database"]["driver"])

--- a/notifier/timing.py
+++ b/notifier/timing.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import logging
+import time
 
 import pycron
 
@@ -14,6 +15,11 @@ def override_current_time(time: str):
     global now
     now = datetime.fromisoformat(time.replace("Z", "+00:00"))
     logger.info(f"Current time forcibly overridden with {time}")
+
+
+def delay():
+    """Pause for a moment."""
+    time.sleep(5)
 
 
 def channel_is_now(crontab: str):

--- a/tests/init.sql
+++ b/tests/init.sql
@@ -1,7 +1,0 @@
-CREATE USER 'root'@'%' IDENTIFIED BY 'root';
-UPDATE mysql.user SET host = '%' WHERE user='root';
-CREATE DATABASE IF NOT EXISTS `wikidot_notifier` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE DATABASE IF NOT EXISTS `wikidot_notifier_test` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-GRANT ALL PRIVILEGES ON `wikidot_notifier_test`.% TO 'root'@'*';
-
-FLUSH PRIVILEGES;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 cleanup() {
-  docker compose -f docker-compose.test.yml stop
+  docker compose -f docker-compose.test.yml down
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Resolves #62 

- [x] Upgrade test runner
- [x] Make tests pass
- [x] Run the prod database on MySQL 8 to see if it works
- [x] Update codebase documentation to refer to MySQL 8


Then if everything looks good:

- [x] Create a Graviton EC2 instance
- [x] Put MySQL 8 on it
- [x] See if it works
- [x] Migrate the database to it
- [x] Point the other microservices to the new instance

If everything works as expected:

- [x] Terminate the MySQL 5.7 instance
- [x] Delete its data
- [x] ~~Update user documentation to refer to MySQL 8, if mentioned at all~~ Not mentioned