### PR TITLE
Remove suffix from guest usernames

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,12 +1,16 @@
 version: '3.8'
 
 services:
-  notifier:
+  notifier_without_db:
     image: notifier:test
     build:
       context: .
       dockerfile: ./Dockerfile
       target: test
+    command: "--notifier-config config/config.toml --notifier-auth config/auth.compose.toml --ignore=tests/test_database.py ${PYTEST_ARGS-}"
+
+  notifier:
+    extends: notifier_without_db
     command: "--notifier-config config/config.toml --notifier-auth config/auth.compose.toml ${PYTEST_ARGS-}"
     links:
       - database

--- a/notifier/parsethread.py
+++ b/notifier/parsethread.py
@@ -157,14 +157,19 @@ def get_user_from_nametag(nametag: Tag) -> Tuple[Optional[str], Optional[str]]:
     classes = nametag.get_attribute_list("class")
     if "avatarhover" in classes:
         user_id = None
+        username = nametag.get_text()
         # Get user ID from JavaScript click event handler
         click_handler = nametag.contents[0].get_attribute_list("onclick")[0]
         if click_handler is not None:
             # Click handler is not present for guest accounts
             match = re.search(r"[0-9]+", click_handler)
             if match:
+                # Real user
                 user_id = match[0]
-        username = nametag.get_text()
+        else:
+            # Guest account
+            if username.endswith(suffix := " (guest)"):
+                username = username[: -len(suffix)]
         return user_id, username
     if "deleted" in classes:
         return nametag.get_attribute_list("data-id")[0], None

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 
+service=notifier
+if [ "$1" = "--no-db" ]; then
+  service=notifier_without_db
+fi
+
 cleanup() {
   docker compose -f docker-compose.test.yml down
 }
 trap cleanup EXIT
 
-docker compose -f docker-compose.test.yml up --build notifier --attach notifier --attach database --exit-code-from notifier
+docker compose -f docker-compose.test.yml up --build $service --attach $service --attach database --exit-code-from $service

--- a/tests/test_parsethread.py
+++ b/tests/test_parsethread.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+from notifier.parsethread import get_user_from_nametag
+
+
+def test_get_user_from_nametag() -> None:
+    @dataclass
+    class UserTag:
+        description: str
+        tag_raw: Tag
+        expected_user_id: Optional[str]
+        expected_username: Optional[str]
+
+        def __post_init__(self):
+            self.tag = BeautifulSoup(self.tag_raw, "html.parser").find(
+                class_="printuser"
+            )
+
+            # Usernames have a 20 character limit
+            if self.expected_username is not None:
+                assert len(self.expected_username) <= 20
+
+    user_tags = [
+        UserTag(
+            "Anonymous user with visible IP",
+            """<span class="printuser anonymous"><a href="javascript:;" onclick="WIKIDOT.page.listeners.anonymousUserInfo('75.142.217.5'); return false;"><img class="small" src="https://www.wikidot.com/common--images/avatars/default/a16.png" alt=""></a><a href="javascript:;" onclick="WIKIDOT.page.listeners.anonymousUserInfo('75.142.217.5'); return false;">Anonymous <span class="ip">(75.142.217.x)</span></a></span>""",
+            None,
+            None,
+        ),
+        UserTag(
+            "Guest user",
+            """<span class="printuser avatarhover"><a href="javascript:;"><img class="small" src="https://secure.gravatar.com/avatar.php?gravatar_id=d0f7d0914b3a679ead94c8a16168f63f&amp;default=https://www.wikidot.com/common--images/avatars/default/a16.png&amp;size=16" alt=""></a>chelonianmobile (guest)</span>""",
+            None,
+            "chelonianmobile",
+        ),
+        UserTag(
+            "Deleted user",
+            """<span class="printuser deleted" data-id="462110"><img class="small" src="https://www.wikidot.com/common--images/avatars/default/a16.png" alt="">(account deleted)</span>""",
+            "462110",
+            None,
+        ),
+        UserTag(
+            "Normal user (from a forum post)",
+            """<span class="printuser avatarhover"><a href="http://www.wikidot.com/user:info/croquembouche" onclick="WIKIDOT.page.listeners.userInfo(2893766); return false;"><img class="small" src="https://www.wikidot.com/avatar.php?userid=2893766&amp;amp;size=small&amp;amp;timestamp=1686573582" alt="Croquembouche" style="background-image:url(https://www.wikidot.com/userkarma.php?u=2893766)"></a><a href="http://www.wikidot.com/user:info/croquembouche" onclick="WIKIDOT.page.listeners.userInfo(2893766); return false;">Croquembouche</a></span>""",
+            "2893766",
+            "Croquembouche",
+        ),
+        UserTag(
+            "System user",
+            """<span class="printuser">Wikidot</span>""",
+            None,
+            "Wikidot",
+        ),
+    ]
+
+    for user_tag in user_tags:
+        assert (
+            user_tag.expected_user_id,
+            user_tag.expected_username,
+        ) == get_user_from_nametag(user_tag.tag)


### PR DESCRIPTION
A guest user had a long name which, combined with the " (guest)" suffix, was longer than the 20 characters allotted for usernames in the database. This was causing an error and preventing posts from being downloaded.

Appears to have been caused by #63. It looks like MySQL 5.6/5.7 permitted these strings to enter the database and be automatically truncated - I can see some usernames ending in e.g. " (gues". MySQL 8 is presumably more strict about this.

I could also write a migration to remove the guest suffix from the cached authors of posts already in the database, but this really doesn't matter, so I haven't.