### PR TITLE
Indicate missed notification count to error users

### DIFF
--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -467,7 +467,7 @@ def notify_user(
                     "reason": "restricted Wikidot inbox",
                 },
             )
-            add_error_tag_to_user("restricted-inbox")
+            add_error_tag_to_user("restricted-inbox", post_count)
             return False, 0, 0
         # This user has fixed the above issue, so remove error tags
         remove_error_tags_from_user()
@@ -501,7 +501,7 @@ def notify_user(
                 },
             )
             # They'll have to fix this themselves - inform them
-            add_error_tag_to_user("not-a-back-contact")
+            add_error_tag_to_user("not-a-back-contact", post_count)
             return False, 0, 0
         # This user has fixed the above issue, so remove error tags
         remove_error_tags_from_user()

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -472,6 +472,8 @@ def notify_user(
             )
             add_error_tag_to_user("restricted-inbox")
             return False, 0, 0
+        # This user has fixed the above issue, so remove the tag
+        remove_error_tag_from_user("restricted-inbox")
 
     # Send the digests via email to email-subscribed users
     if user["delivery"] == "email":


### PR DESCRIPTION
Resolves #67

-----

The term 'error user' refers to a user with an error that prevents Notifier from contacting them. Currently the only conditions that cause that are

1. user wants PMs but inbox is closed and Notifier is not granted permission
2. user wants emails but Notifier can't access their email address

-----

Plan as per #67 is to take the count of missed notifications for a user and add it as a hidden tag to their user config page. Other pages on the site can then display that value natively.

The notification service will not be able to inform that user about the issue, but if the number is high enough, that can be enough to justify manual intervention; i.e.:

> "Please fix your config, you have X missed notifications"

is vastly preferable to

> "Please fix your config, you are cluttering the user list"

-----

- [x] ~~Save count of notifications per error user~~
  * There is actually no need to do this, the tagging is done directly in the notification procedure - I thought it was part of cleanup
- [x] Tag error user config pages ~~during cleanup~~
- [x] Ensure old count tag is removed
- [x] Remove count tag when the notification is successful, if there is one
