### PR TITLE
Route egress via API Gateway proxy

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -413,9 +413,10 @@ Create the trigger, then find it in the EventBridge console, and edit it:
 
 ```json
 {
-  "db_instance_id": "i-01708f003d7c13d71",
+  "db_instance_id": "i-<id>",
   "config_path": "config/config.toml",
-  "auth_path": "config/auth.lambda.toml"
+  "auth_path": "config/auth.lambda.toml",
+  "proxy": "https://<id>.execute-api.<region>.amazonaws.com/dev/proxy?target_url="
 }
 ```
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -57,7 +57,7 @@ def lambda_handler(event: Dict[str, str], context: Any) -> int:
     )
     main(
         config=read_local_config(local_config_path),
-        auth=read_local_auth(local_auth_path),
+        auth=read_local_auth(local_auth_path, proxy=proxy),
         execute_now=[],
         force_current_time=force_current_time,
         proxy=proxy,

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -41,16 +41,26 @@ def lambda_handler(event: Dict[str, str], context: Any) -> int:
         raise ValueError("Missing key auth_path in event")
     local_auth_path = event["auth_path"]
 
+    proxy = event.get("proxy", "")
+
     force_current_time = None
     if "force_current_time" in event:
         force_current_time = event["force_current_time"]
 
-    logger.debug("Lambda: starting main procedure")
+    logger.debug(
+        "Lambda: starting main procedure %s",
+        {
+            "local_config_path": local_config_path,
+            "local_auth_path": local_auth_path,
+            "proxy": proxy,
+        },
+    )
     main(
         config=read_local_config(local_config_path),
         auth=read_local_auth(local_auth_path),
         execute_now=[],
         force_current_time=force_current_time,
+        proxy=proxy,
     )
     logger.info("Lambda finished")
     return 0

--- a/notifier/config/local.py
+++ b/notifier/config/local.py
@@ -74,7 +74,7 @@ def read_local_config(config_path: str) -> LocalConfig:
     raise RuntimeError
 
 
-def read_local_auth(auth_path: str) -> AuthConfig:
+def read_local_auth(auth_path: str, *, proxy: str = "") -> AuthConfig:
     """Reads the local auth file from the specified path."""
     logger.debug("Reading local auth config %s", {"path": auth_path})
     with open(auth_path, "r", encoding="utf-8") as auth_file:
@@ -97,6 +97,7 @@ def read_local_auth(auth_path: str) -> AuthConfig:
                 external_source["region_name"],
                 external_source["secret_name"],
                 external_source["use_keys"],
+                proxy=proxy,
             )
         )
         logger.debug("Supplemented secret %s", {"index": index})

--- a/notifier/config/remote.py
+++ b/notifier/config/remote.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import boto3
 import requests
@@ -78,22 +78,28 @@ class AWS:
     client = None
 
     @staticmethod
-    def _get_client(region_name: str) -> Any:
+    def _get_client(region_name: str, proxy: str) -> Any:
         """Makes or retrieves a connection client."""
         if AWS.client is None:
             AWS.session = boto3.session.Session()
             AWS.client = AWS.session.client(
-                service_name="secretsmanager", region_name=region_name
+                service_name="secretsmanager",
+                region_name=region_name,
+                endpoint_url=f"{proxy}https://secretsmanager.{region_name}.amazonaws.com",
             )
         return AWS.client
 
     @staticmethod
     def get_secrets(
-        region_name: str, secret_name: str, mapping: List[Tuple[str, str]]
+        region_name: str,
+        secret_name: str,
+        mapping: List[Tuple[str, str]],
+        *,
+        proxy: str = "",
     ) -> Dict[str, str]:
         """Retrieves secrets from Secrets Manager."""
         secrets = json.loads(
-            AWS._get_client(region_name).get_secret_value(
+            AWS._get_client(region_name, proxy).get_secret_value(
                 SecretId=secret_name
             )["SecretString"]
         )

--- a/notifier/main.py
+++ b/notifier/main.py
@@ -24,6 +24,7 @@ def main(
     limit_wikis: Optional[List[str]] = None,
     force_initial_search_timestamp: Optional[int] = None,
     force_current_time: Optional[str] = None,
+    proxy: Optional[str] = None,
     dry_run: bool = False,
 ) -> None:
     """Main notifier application entrypoint."""
@@ -69,6 +70,7 @@ def main(
                 database=database,
                 limit_wikis=limit_wikis,
                 force_initial_search_timestamp=force_initial_search_timestamp,
+                proxy=proxy,
                 dry_run=dry_run,
             ),
             CronTrigger.from_crontab(notification_channels["hourly"]),
@@ -92,6 +94,7 @@ def main(
             database=database,
             limit_wikis=limit_wikis,
             force_initial_search_timestamp=force_initial_search_timestamp,
+            proxy=proxy,
             dry_run=dry_run,
         )
 

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -79,6 +79,7 @@ def notify(
     database: BaseDatabaseDriver,
     limit_wikis: Optional[List[str]] = None,
     force_initial_search_timestamp: Optional[int] = None,
+    proxy: Optional[str] = None,
     dry_run: bool = False,
 ) -> None:
     """Main task executor. Should be called as often as the most frequent
@@ -97,7 +98,7 @@ def notify(
         return
 
     connection = Connection(
-        config, database.get_supported_wikis(), dry_run=dry_run
+        config, database.get_supported_wikis(), dry_run=dry_run, proxy=proxy
     )
 
     config_start_timestamp = timestamp()
@@ -110,7 +111,9 @@ def notify(
         get_user_config(config, database, connection)
 
         # Refresh the connection to add any newly-configured wikis
-        connection = Connection(config, database.get_supported_wikis())
+        connection = Connection(
+            config, database.get_supported_wikis(), proxy=proxy
+        )
     config_end_timestamp = timestamp()
 
     getpost_start_timestamp = timestamp()

--- a/notifier/wikiconnection.py
+++ b/notifier/wikiconnection.py
@@ -60,9 +60,11 @@ class Connection:
         config: LocalConfig,
         supported_wikis: List[SupportedWikiConfig],
         *,
+        proxy: Optional[str],
         dry_run: bool = False,
     ):
         """Connect to Wikidot."""
+        self.proxy = proxy or ""
         self.dry_run = dry_run
         if self.dry_run:
             # Theoretically the session will never be used in a dry run
@@ -101,7 +103,9 @@ class Connection:
                 "Dry run: Wikidot request was not sent %s", {"to": url}
             )
             return None
-        return self._session.request("POST", url, **request_kwargs)
+        return self._session.request(
+            "POST", self.proxy + url, **request_kwargs
+        )
 
     def module(
         self, wiki_id: str, module_name: str, **module_kwargs: Any
@@ -433,7 +437,7 @@ class Connection:
         page_url = "http{}://{}.wikidot.com/{}".format(
             "s" if wiki["secure"] else "", wiki_id, slug
         )
-        page = self._session.get(page_url).text
+        page = self._session.get(self.proxy + page_url).text
         return int(
             cast(Match[str], re.search(r"pageId = ([0-9]+);", page)).group(1)
         )


### PR DESCRIPTION
This circumvents costs associated with EIPs by routing external requests through an API Gateway hosting a serverless proxy.

* Resolves #87

Serverless proxy is in place already.

- [x] Route WD requests
- [x] Route Secrets Manager requests
- [ ] Route S3 requests - I don't think this is necessary because there's the option of using a Gateway-type PrivateLink for S3 (which is free), but needs verification (I haven't put any security group on it yet, and haven't even worked out if I need to access it from a specific URL, so it probably doesn't work right now
- [ ] Route email requests - have been approved for SES for this purpose