### PR TITLE
Track last seen post timestamp per wiki

### DIFF
--- a/notifier/database/drivers/base.py
+++ b/notifier/database/drivers/base.py
@@ -112,6 +112,12 @@ class BaseDatabaseDriver(ABC):
         that are already present."""
 
     @abstractmethod
+    def store_latest_post_timestamp(
+        self, wiki_id: str, timestamp: int
+    ) -> None:
+        """Stores the latest seen post timestamp for the given wiki."""
+
+    @abstractmethod
     def store_post(self, post: NotifiablePost) -> None:
         """Store a post."""
 

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -370,7 +370,7 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
     ) -> None:
         self.execute_named(
             "store_latest_post_timestamp",
-            { "wiki_id": wiki_id, "timestamp": timestamp },
+            {"wiki_id": wiki_id, "timestamp": timestamp},
         )
 
     def store_post(self, post: NotifiablePost) -> None:

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -365,6 +365,14 @@ class MySqlDriver(BaseDatabaseDriver, BaseDatabaseWithSqlFileCache):
                 )
             # Wikis that were removed from the service since the last run are still available as context
 
+    def store_latest_post_timestamp(
+        self, wiki_id: str, timestamp: int
+    ) -> None:
+        self.execute_named(
+            "store_latest_post_timestamp",
+            { "wiki_id": wiki_id, "timestamp": timestamp },
+        )
+
     def store_post(self, post: NotifiablePost) -> None:
         self.execute_named(
             "store_post",

--- a/notifier/database/migrations/010-track-latest-timestamp-per-wiki.down.sql
+++ b/notifier/database/migrations/010-track-latest-timestamp-per-wiki.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  context_wiki
+DROP COLUMN
+  new_posts_checked_timestamp;

--- a/notifier/database/migrations/010-track-latest-timestamp-per-wiki.up.sql
+++ b/notifier/database/migrations/010-track-latest-timestamp-per-wiki.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+  context_wiki
+ADD COLUMN
+  new_posts_checked_timestamp INT UNSIGNED NOT NULL;
+
+UPDATE
+  context_wiki
+SET
+  new_posts_checked_timestamp = 0;

--- a/notifier/database/queries/delete_non_notifiable_posts.sql
+++ b/notifier/database/queries/delete_non_notifiable_posts.sql
@@ -15,8 +15,8 @@ WHERE
   notifiable_post.posted_timestamp < ((
     SELECT latest_timestamp FROM (
       SELECT
-        MAX(posted_timestamp) AS latest_timestamp
-      FROM notifiable_post
+        MAX(new_posts_checked_timestamp) AS latest_timestamp
+      FROM context_wiki
     ) AS t
   ) - (60 * 60 * 24 * 365))
 

--- a/notifier/database/queries/get_latest_post_timestamp.sql
+++ b/notifier/database/queries/get_latest_post_timestamp.sql
@@ -1,6 +1,6 @@
 SELECT
-  MAX(posted_timestamp) as posted_timestamp
+  new_posts_checked_timestamp
 FROM
-  notifiable_post
+  context_wiki
 WHERE
-  notifiable_post.context_wiki_id = %(wiki_id)s
+  context_wiki.wiki_id = %(wiki_id)s

--- a/notifier/database/queries/get_latest_post_timestamp.sql
+++ b/notifier/database/queries/get_latest_post_timestamp.sql
@@ -1,5 +1,5 @@
 SELECT
-  new_posts_checked_timestamp
+  new_posts_checked_timestamp AS posted_timestamp
 FROM
   context_wiki
 WHERE

--- a/notifier/database/queries/store_context_wiki.sql
+++ b/notifier/database/queries/store_context_wiki.sql
@@ -4,14 +4,16 @@ INSERT INTO
     wiki_id,
     wiki_name,
     wiki_service_configured,
-    wiki_uses_https
+    wiki_uses_https,
+    new_posts_checked_timestamp
   )
 VALUES
   (
     %(wiki_id)s,
     %(wiki_name)s,
     %(wiki_service_configured)s,
-    %(wiki_uses_https)s
+    %(wiki_uses_https)s,
+    0
   )
 ON DUPLICATE KEY UPDATE
   wiki_name = %(wiki_name)s,

--- a/notifier/database/queries/store_latest_post_timestamp.sql
+++ b/notifier/database/queries/store_latest_post_timestamp.sql
@@ -1,0 +1,6 @@
+UPDATE
+  context_wiki
+SET
+  new_posts_checked_timestamp = %(timestamp)s
+WHERE
+  context_wiki.wiki_id = %(wiki_id)s

--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -75,6 +75,12 @@ def fetch_posts_with_context(
         },
     )
 
+    # If there's at least one post, store the new highest timestamp for this wiki
+    if len(new_posts) > 0:
+        database.store_latest_post_timestamp(
+            wiki_id, max(post["posted_timestamp"] for post in new_posts)
+        )
+
     # Cache the latest downloaded thread to prevent multiple identical downloads when multiple posts share a thread
     thread_meta: RawThreadMeta = None  # type:ignore
     thread_page_posts: List[RawPost] = []


### PR DESCRIPTION
2a85c2ce007d149e9974ab14d1e694a080ae6666 fixed a bug where a post would be skipped being downloaded if a post was stored with a later timestamp than it, which because posts are downloaded ordered by wiki and not by timestamp, was causing almost all posts to be skipped. It fixed it by limiting the 'latest timestamp' search only to posts from the given wiki.

While effective, this is not efficient. Most downloaded posts are deleted during the very same run, meaning on the next run, many of those same posts will be downloaded again, wasting time and networking resources.

This PR fixes this by recording the last time that posts were downloaded from a wiki in the context_wiki table. This recording will be permanent, even if the corresponding post is deleted.