### PR TITLE
Fail gracefully when getting a page during a bork

### DIFF
--- a/notifier/newposts.py
+++ b/notifier/newposts.py
@@ -130,7 +130,6 @@ def fetch_posts_with_context(
                     "post_id": post_id,
                 },
             )
-            raise RuntimeError("Requested post missing from downloaded thread")
 
         # For each kind of context, check if we already have it, and if not, fetch it
 

--- a/notifier/wikidot.py
+++ b/notifier/wikidot.py
@@ -154,7 +154,7 @@ class Wikidot:
                     cookies={"wikidot_token7": token7},
                 )
             except ConnectionError as error:
-                will_retry = attempt_count > self.MODULE_ATTEMPT_LIMIT
+                will_retry = attempt_count < self.MODULE_ATTEMPT_LIMIT
                 logger.debug(
                     "Module connection failed %s",
                     {
@@ -189,7 +189,7 @@ class Wikidot:
                 and response["message"]
                 == "An error occurred while processing the request."
             ):
-                will_retry = attempt_count > self.MODULE_ATTEMPT_LIMIT
+                will_retry = attempt_count < self.MODULE_ATTEMPT_LIMIT
                 if will_retry:
                     logger.warning(
                         "Wikidot internal failure, retrying in 10 seconds %s",

--- a/notifier/wikidot.py
+++ b/notifier/wikidot.py
@@ -455,14 +455,14 @@ class Wikidot:
             )
         )
 
-        page = None
+        page_text = None
         for attempt_count in range(self.MODULE_ATTEMPT_LIMIT):
             attempt_delay = 2**attempt_count * self.PAGINATION_DELAY_S
             will_retry = attempt_count < self.MODULE_ATTEMPT_LIMIT
             time.sleep(attempt_delay)
-            page = self._session.get(page_url).text
+            response = self._session.get(page_url)
 
-            if page.is_wikidot_error():
+            if response.status_code == 500:
                 logger.warning(
                     "Wikibork when getting page %s",
                     {
@@ -473,12 +473,33 @@ class Wikidot:
                         "will_retry": will_retry,
                     },
                 )
-            if not will_retry:
+                if will_retry:
+                    continue
                 raise Wikibork
-        assert page is not None
+
+            if response.status_code != 200:
+                logger.warning(
+                    "Failed to get page %s",
+                    {
+                        "url": page_url,
+                        "status_code": response.status_code,
+                        "attempt_number": attempt_count + 1,
+                        "attempt_delay_s": attempt_delay,
+                        "max_attempts": self.MODULE_ATTEMPT_LIMIT,
+                        "will_retry": will_retry,
+                    },
+                )
+                if will_retry:
+                    continue
+                raise OngoingConnectionError
+
+            page_text = response.text
+        assert page_text is not None
 
         return int(
-            cast(Match[str], re.search(r"pageId = ([0-9]+);", page)).group(1)
+            cast(
+                Match[str], re.search(r"pageId = ([0-9]+);", page_text)
+            ).group(1)
         )
 
     def rename_page(self, wiki_id: str, from_slug: str, to_slug: str) -> None:


### PR DESCRIPTION
During a wikibork, Wikidot will show an error page. I believe this is what is causing an error when trying to get a page ID, because I do not verify the content of the page before getting the ID, and receiving an error page means the request technically succeeded.

I need to work out how to reliably detect an error page before I can complete this.

- [x] ~~Detect 200 error page~~ Actually it is a 500
- [x] Detect 500 error

Naive solution if I can't: page ID not in page AND some known error text present.

Countercase: theme:wikifot must not match.