### PR TITLE
Send confirmation messages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@
 **/bin
 **/charts
 **/docker-compose*
-**/compose*
 **/Dockerfile*
 **/node_modules
 **/npm-debug.log

--- a/config/lang.toml
+++ b/config/lang.toml
@@ -87,7 +87,7 @@ frequency_weekly = "weekly"
 frequency_monthly = "monthly"
 subject = "[Forum Notifications] {post_count} new plural({post_count}|post|posts)"
 intro = """|
-Hello! This is your {frequency} notification digest from {link_site}, notifying you of new posts to threads that you're subscribed to.
+Hello! This is your {frequency} notification digest from {link_site}, notifying you of new posts to Wikidot threads that you're subscribed to.
 
 This service is keeping track of:
 
@@ -112,15 +112,29 @@ unknown_category_name = "Other"
 thread_opener = "Thread:"
 post_replies_opener = "Replies to post:"
 untitled_post_title = "(untitled post)"
-confirmation_subject = "[Forum Notifications] Signup confirmation"
-confirmation_message = """|
-Thank you for signing up for forum notifications at {link_site}! This is your confirmation that you're ready to receive notifications.
 
-Your user config is located at {link_your_config}. Edit it to change your frequency (currently {frequency}), language, subscriptions and unsubscriptions.
+signup_confirmation_subject = "[Forum Notifications] Signup confirmation"
+signup_confirmation_message = """|
+Thank you for signing up for [{link_site} Wikidot forum notifications]! This is your confirmation that you're ready to receive notifications.
 
-Keep an eye on your user config page -- if there's a problem preventing notifications from being sent to you, a message will be added to it with info about the problem and instructions on how to fix it.
+Your user config is located at {link_your_config}. Consider bookmarking it.
 
-To unsubscribe from notifications, [{link_your_config} edit your user config] and change your frequency to 'never', or ask [[*user Croquembouche]] to delete your config entirely.
+Edit your user config to change your frequency (currently {frequency}), delivery method, language, subscriptions and unsubscriptions.
+
+Keep an eye on your user config -- if there's a problem preventing notifications from being sent to you, a message will be added to it with info about the problem and instructions on how to fix it.
+
+To unsubscribe from notifications, edit your user config and change your frequency to 'never'. Or, you can ask [[*user Croquembouche]] to delete your user config entirely.
+"""
+
+method_pm = "Wikidot private message"
+method_email = "email"
+methodchange_confirmation_subject = "[Forum Notifications] Delivery method changed"
+methodchange_confirmation_message = """|
+This is your confirmation that your delivery method for [{link_site} Wikidot forum notifications] has been changed.
+
+If you received this message, your delivery method was successfully changed from {old_method} to {new_method}.
+
+You change it back by editing your user config at {link_your_config}.
 """
 
 [vi]
@@ -179,8 +193,7 @@ Ce service suit actuellement :
 
 * Abonnements automatiques à des fils et des messages. [{link_info_automatic} Apprenez ce que constitue un abonnement automatique.]
 
-Ce compte ([[*user Notifier]]) est automatisé -- les réponses à ce message ne seront pas prises en compte. Si vous avez un problème, contactez directement [[*user
-Croquembouche]] (en anglais).
+Ce compte ([[*user Notifier]]) est automatisé -- les réponses à ce message ne seront pas prises en compte. Si vous avez un problème, contactez directement [[*user Croquembouche]] (en anglais).
 
 -----
 

--- a/config/lang.toml
+++ b/config/lang.toml
@@ -112,6 +112,16 @@ unknown_category_name = "Other"
 thread_opener = "Thread:"
 post_replies_opener = "Replies to post:"
 untitled_post_title = "(untitled post)"
+confirmation_subject = "[Forum Notifications] Signup confirmation"
+confirmation_message = """|
+Thank you for signing up for forum notifications at {link_site}! This is your confirmation that you're ready to receive notifications.
+
+Your user config is located at {link_your_config}. Edit it to change your frequency (currently {frequency}), language, subscriptions and unsubscriptions.
+
+Keep an eye on your user config page -- if there's a problem preventing notifications from being sent to you, a message will be added to it with info about the problem and instructions on how to fix it.
+
+To unsubscribe from notifications, [{link_your_config} edit your user config] and change your frequency to 'never', or ask [[*user Croquembouche]] to delete your config entirely.
+"""
 
 [vi]
 frequency_hourly = "hàng giờ"

--- a/notifier/composer.py
+++ b/notifier/composer.py
@@ -44,7 +44,7 @@ def make_thread_url(
 
 
 class Composer:
-    """Constructs notification digests."""
+    """Composes messages."""
 
     def __init__(self, lang_path: str):
         # Read the strings from the lang file into a lexicon

--- a/notifier/composer.py
+++ b/notifier/composer.py
@@ -9,12 +9,10 @@ from typing import (
     Dict,
     Iterable,
     List,
-    Literal,
     Optional,
     Sequence,
     Set,
     Tuple,
-    Union,
     cast,
     Match,
 )
@@ -45,7 +43,7 @@ def make_thread_url(
     )
 
 
-class Digester:
+class Composer:
     """Constructs notification digests."""
 
     def __init__(self, lang_path: str):
@@ -70,99 +68,61 @@ class Digester:
         lexicon = process_long_lexicon_strings(lexicon)
         return lexicon
 
-    def for_user(
+    def make_notification_digest(
         self,
         user: CachedUserConfig,
         posts: Sequence[PostInfo],
-        *,
-        template: Union[Literal["notification"], Literal["confirmation"]],
     ) -> Tuple[str, str]:
-        """Compile a notification digest for a user.
-
-        Returns a tuple of message subject and the digest body.
-        """
-        # Make the lexicon for this user's settings
+        """Makes a notification digest. Returns subject and body."""
         lang = user["language"]
         lexicon = self.make_lexicon(lang)
-        if template == "confirmation":
-            return make_confirmation_message(user, lexicon, lang)
-        if template == "notification":
-            return make_notification_digest(user, posts, lexicon, lang)
-        raise ValueError(f"Unknown digest template f{template}")
-
-
-def make_confirmation_message(
-    user: CachedUserConfig, lexicon: Lexicon, lang: str
-) -> Tuple[str, str]:
-    """Makes a signup confirmation message. Returns subject and body."""
-    subject = lexicon["confirmation_subject"]
-    body = lexicon["confirmation_message"].format(
-        link_site=lexicon["link_site"],
-        link_your_config=lexicon["link_your_config"].format(
-            link_site=lexicon["link_site"]
-        ),
-        frequency={
+        # Get some stats for the message
+        manual_sub_count = len(
+            [sub for sub in user["manual_subs"] if sub["sub"] == 1]
+        )
+        total_notification_count = len(posts)
+        # Construct the message
+        subject = lexicon["subject"].format(
+            post_count=total_notification_count
+        )
+        frequency = {
             "hourly": lexicon["frequency_hourly"],
             "8hourly": lexicon["frequency_8hourly"],
             "daily": lexicon["frequency_daily"],
             "weekly": lexicon["frequency_weekly"],
             "monthly": lexicon["frequency_monthly"],
             "test": lexicon["frequency_test"],
-        }.get(user["frequency"], "undefined"),
-    )
-    return subject, body
-
-
-def make_notification_digest(
-    user: CachedUserConfig, posts: Sequence[PostInfo], lexicon: Lexicon,
-    lang: str,
-) -> Tuple[str, str]:
-    """Makes a notification digest. Returns subject and body."""
-    # Get some stats for the message
-    manual_sub_count = len(
-        [sub for sub in user["manual_subs"] if sub["sub"] == 1]
-    )
-    total_notification_count = len(posts)
-    # Construct the message
-    subject = lexicon["subject"].format(post_count=total_notification_count)
-    frequency = {
-        "hourly": lexicon["frequency_hourly"],
-        "8hourly": lexicon["frequency_8hourly"],
-        "daily": lexicon["frequency_daily"],
-        "weekly": lexicon["frequency_weekly"],
-        "monthly": lexicon["frequency_monthly"],
-        "test": lexicon["frequency_test"],
-    }.get(user["frequency"], "undefined")
-    intro = lexicon["intro"].format(
-        frequency=frequency,
-        link_site=lexicon["link_site"],
-        manual_sub_count=manual_sub_count,
-        link_your_config=lexicon["link_your_config"].format(
-            link_site=lexicon["link_site"]
-        ),
-        link_info_learning=lexicon["link_info_learning"].format(
-            link_site=lexicon["link_site"]
-        ),
-        link_info_automatic=lexicon["link_info_automatic"].format(
-            link_site=lexicon["link_site"]
-        ),
-    )
-    outro = lexicon["outro"].format(
-        unsub_footer=lexicon["unsub_footer"].format(
-            link_unsubscribe=lexicon["link_unsubscribe"].format(
+        }.get(user["frequency"], "undefined")
+        intro = lexicon["intro"].format(
+            frequency=frequency,
+            link_site=lexicon["link_site"],
+            manual_sub_count=manual_sub_count,
+            link_your_config=lexicon["link_your_config"].format(
                 link_site=lexicon["link_site"]
+            ),
+            link_info_learning=lexicon["link_info_learning"].format(
+                link_site=lexicon["link_site"]
+            ),
+            link_info_automatic=lexicon["link_info_automatic"].format(
+                link_site=lexicon["link_site"]
+            ),
+        )
+        outro = lexicon["outro"].format(
+            unsub_footer=lexicon["unsub_footer"].format(
+                link_unsubscribe=lexicon["link_unsubscribe"].format(
+                    link_site=lexicon["link_site"]
+                )
             )
         )
-    )
-    body = lexicon["body"].format(
-        intro=intro,
-        wikis="\n".join(make_wikis_digest(posts, lexicon)),
-        outro=outro,
-    )
-    subject = pluralise(subject, lang)
-    body = finalise_digest(body, lang)
-    body = convert_syntax(body, user["delivery"])
-    return subject, body
+        body = lexicon["body"].format(
+            intro=intro,
+            wikis="\n".join(make_wikis_digest(posts, lexicon)),
+            outro=outro,
+        )
+        subject = pluralise(subject, lang)
+        body = finalise_digest(body, lang)
+        body = convert_syntax(body, user["delivery"])
+        return subject, body
 
 
 def make_wikis_digest(

--- a/notifier/composer.py
+++ b/notifier/composer.py
@@ -82,8 +82,9 @@ class Composer:
         )
         total_notification_count = len(posts)
         # Construct the message
-        subject = lexicon["subject"].format(
-            post_count=total_notification_count
+        subject = pluralise(
+            lexicon["subject"].format(post_count=total_notification_count),
+            lang,
         )
         frequency = {
             "hourly": lexicon["frequency_hourly"],
@@ -119,8 +120,66 @@ class Composer:
             wikis="\n".join(write_wikis_digest(posts, lexicon)),
             outro=outro,
         )
-        subject = pluralise(subject, lang)
-        body = finalise_digest(body, lang)
+        body = postprocess_message(body, lang)
+        body = convert_syntax(body, user["delivery"])
+        return subject, body
+
+    def write_signup_confirmation(
+        self,
+        user: CachedUserConfig,
+    ) -> Tuple[str, str]:
+        """Writes a signup confirmation message."""
+        lang = user["language"]
+        lexicon = self.build_lexicon(lang)
+        frequency = {
+            "hourly": lexicon["frequency_hourly"],
+            "8hourly": lexicon["frequency_8hourly"],
+            "daily": lexicon["frequency_daily"],
+            "weekly": lexicon["frequency_weekly"],
+            "monthly": lexicon["frequency_monthly"],
+            "test": lexicon["frequency_test"],
+        }.get(user["frequency"], "undefined")
+
+        subject = lexicon["signup_confirmation_subject"]
+
+        body = lexicon["signup_confirmation_body"].format(
+            link_site=lexicon["link_site"],
+            link_your_config=lexicon["link_your_config"].format(
+                link_site=lexicon["link_site"]
+            ),
+            frequency=frequency,
+        )
+        body = postprocess_message(body, lang)
+        body = convert_syntax(body, user["delivery"])
+        return subject, body
+
+    def write_methodchange_confirmation(
+        self,
+        user: CachedUserConfig,
+    ) -> Tuple[str, str]:
+        """Writes a delivery method change confirmation message."""
+        lang = user["language"]
+        lexicon = self.build_lexicon(lang)
+
+        subject = lexicon["methodchange_confirmation_subject"]
+
+        body = lexicon["methodchange_confirmation_message"].format(
+            link_site=lexicon["link_site"],
+            link_your_config=lexicon["link_your_config"].format(
+                link_site=lexicon["link_site"]
+            ),
+            old_method=(
+                lexicon["method_pm"]
+                if user["delivery"] == "pm"
+                else lexicon["method_email"]
+            ),
+            new_method=(
+                lexicon["method_pm"]
+                if user["delivery"] == "email"
+                else lexicon["method_email"]
+            ),
+        )
+        body = postprocess_message(body, lang)
         body = convert_syntax(body, user["delivery"])
         return subject, body
 
@@ -363,8 +422,8 @@ def make_plural_for_lang(match: Match[str], lang: str) -> str:
     return multiple
 
 
-def finalise_digest(digest: str, lang: str) -> str:
-    """Performs final postprocessing on a digest."""
+def postprocess_message(digest: str, lang: str) -> str:
+    """Performs final postprocessing on a message."""
     return emojize(pluralise(digest, lang), variant="emoji_type")
 
 

--- a/notifier/composer.py
+++ b/notifier/composer.py
@@ -54,7 +54,7 @@ class Composer:
             )
 
     @lru_cache(maxsize=1)
-    def make_lexicon(self, lang: str) -> Lexicon:
+    def build_lexicon(self, lang: str) -> Lexicon:
         """Constructs a subset of the full lexicon for a given language."""
         # Later keys in the lexicon will override previous ones - e.g. for
         # a non-en language, its keys should override all of en's, but in
@@ -68,14 +68,14 @@ class Composer:
         lexicon = process_long_lexicon_strings(lexicon)
         return lexicon
 
-    def make_notification_digest(
+    def write_notification_digest(
         self,
         user: CachedUserConfig,
         posts: Sequence[PostInfo],
     ) -> Tuple[str, str]:
         """Makes a notification digest. Returns subject and body."""
         lang = user["language"]
-        lexicon = self.make_lexicon(lang)
+        lexicon = self.build_lexicon(lang)
         # Get some stats for the message
         manual_sub_count = len(
             [sub for sub in user["manual_subs"] if sub["sub"] == 1]
@@ -116,7 +116,7 @@ class Composer:
         )
         body = lexicon["body"].format(
             intro=intro,
-            wikis="\n".join(make_wikis_digest(posts, lexicon)),
+            wikis="\n".join(write_wikis_digest(posts, lexicon)),
             outro=outro,
         )
         subject = pluralise(subject, lang)
@@ -125,7 +125,7 @@ class Composer:
         return subject, body
 
 
-def make_wikis_digest(
+def write_wikis_digest(
     posts: Sequence[PostInfo], lexicon: Lexicon
 ) -> List[str]:
     """Makes the notification list for wikis."""
@@ -139,14 +139,14 @@ def make_wikis_digest(
             lexicon["wiki"].format(
                 wiki_name=wiki_posts[0]["wiki_name"],
                 categories="\n".join(
-                    make_categories_digest(wiki_posts, lexicon)
+                    write_categories_digest(wiki_posts, lexicon)
                 ),
             )
         )
     return digests
 
 
-def make_categories_digest(
+def write_categories_digest(
     posts: Sequence[PostInfo], lexicon: Lexicon
 ) -> List[str]:
     """Makes the notification list for categories in a given wiki."""
@@ -155,7 +155,7 @@ def make_categories_digest(
     # Sort categories by notification count
     for category_id in frequent_ids(grouped_posts):
         category_posts = grouped_posts[category_id]
-        threads = make_threads_digest(category_posts, lexicon)
+        threads = write_threads_digest(category_posts, lexicon)
         digests.append(
             lexicon["category"].format(
                 category_name=category_posts[0].get("category_name")
@@ -170,7 +170,7 @@ def make_categories_digest(
     return digests
 
 
-def make_threads_digest(
+def write_threads_digest(
     posts: Sequence[PostInfo],
     lexicon: Lexicon,
 ) -> List[str]:
@@ -198,13 +198,13 @@ def make_threads_digest(
         posts_section = ""
         if len(posts) > 0:
             posts_section = lexicon["posts_section"].format(
-                posts="\n".join(make_posts_digest(posts, lexicon))
+                posts="\n".join(write_posts_digest(posts, lexicon))
             )
         replies_section = ""
         if len(replies) > 0:
             replies_section = lexicon["replies_section"].format(
                 posts_replied_to="\n".join(
-                    make_post_replies_digest(replies, lexicon)
+                    write_post_replies_digest(replies, lexicon)
                 )
             )
         first_post = (posts + replies)[0]
@@ -236,7 +236,7 @@ def make_threads_digest(
     return digests
 
 
-def make_post_replies_digest(
+def write_post_replies_digest(
     post_replies: Sequence[PostInfo], lexicon: Lexicon
 ) -> List[str]:
     """Makes the notification list for replies in a given thread."""
@@ -248,7 +248,7 @@ def make_post_replies_digest(
     )
     for parent_post_id, replies_group in grouped_replies:
         replies = list(replies_group)
-        posts = make_posts_digest(replies, lexicon)
+        posts = write_posts_digest(replies, lexicon)
         digests.append(
             lexicon["post_replied_to"].format(
                 post_replies_opener=lexicon["post_replies_opener"],
@@ -275,14 +275,14 @@ def make_post_replies_digest(
     return digests
 
 
-def make_posts_digest(
+def write_posts_digest(
     posts: Iterable[PostInfo], lexicon: Lexicon
 ) -> List[str]:
     """Makes the notification list for new posts."""
-    return [make_post_digest(post, lexicon) for post in posts]
+    return [write_post_digest(post, lexicon) for post in posts]
 
 
-def make_post_digest(post: PostInfo, lexicon: Lexicon) -> str:
+def write_post_digest(post: PostInfo, lexicon: Lexicon) -> str:
     """Makes a notification for a single post."""
     return lexicon["post"].format(
         post_url=make_thread_url(

--- a/notifier/digest.py
+++ b/notifier/digest.py
@@ -9,10 +9,12 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
     Tuple,
+    Union,
     cast,
     Match,
 )
@@ -69,7 +71,11 @@ class Digester:
         return lexicon
 
     def for_user(
-        self, user: CachedUserConfig, posts: Sequence[PostInfo]
+        self,
+        user: CachedUserConfig,
+        posts: Sequence[PostInfo],
+        *,
+        template: Union[Literal["notification"], Literal["confirmation"]],
     ) -> Tuple[str, str]:
         """Compile a notification digest for a user.
 
@@ -78,53 +84,85 @@ class Digester:
         # Make the lexicon for this user's settings
         lang = user["language"]
         lexicon = self.make_lexicon(lang)
-        # Get some stats for the message
-        manual_sub_count = len(
-            [sub for sub in user["manual_subs"] if sub["sub"] == 1]
-        )
-        total_notification_count = len(posts)
-        # Construct the message
-        subject = lexicon["subject"].format(
-            post_count=total_notification_count
-        )
-        frequency = {
+        if template == "confirmation":
+            return make_confirmation_message(user, lexicon, lang)
+        if template == "notification":
+            return make_notification_digest(user, posts, lexicon, lang)
+        raise ValueError(f"Unknown digest template f{template}")
+
+
+def make_confirmation_message(
+    user: CachedUserConfig, lexicon: Lexicon, lang: str
+) -> Tuple[str, str]:
+    """Makes a signup confirmation message. Returns subject and body."""
+    subject = lexicon["confirmation_subject"]
+    body = lexicon["confirmation_message"].format(
+        link_site=lexicon["link_site"],
+        link_your_config=lexicon["link_your_config"].format(
+            link_site=lexicon["link_site"]
+        ),
+        frequency={
             "hourly": lexicon["frequency_hourly"],
             "8hourly": lexicon["frequency_8hourly"],
             "daily": lexicon["frequency_daily"],
             "weekly": lexicon["frequency_weekly"],
             "monthly": lexicon["frequency_monthly"],
             "test": lexicon["frequency_test"],
-        }.get(user["frequency"], "undefined")
-        intro = lexicon["intro"].format(
-            frequency=frequency,
-            link_site=lexicon["link_site"],
-            manual_sub_count=manual_sub_count,
-            link_your_config=lexicon["link_your_config"].format(
+        }.get(user["frequency"], "undefined"),
+    )
+    return subject, body
+
+
+def make_notification_digest(
+    user: CachedUserConfig, posts: Sequence[PostInfo], lexicon: Lexicon,
+    lang: str,
+) -> Tuple[str, str]:
+    """Makes a notification digest. Returns subject and body."""
+    # Get some stats for the message
+    manual_sub_count = len(
+        [sub for sub in user["manual_subs"] if sub["sub"] == 1]
+    )
+    total_notification_count = len(posts)
+    # Construct the message
+    subject = lexicon["subject"].format(post_count=total_notification_count)
+    frequency = {
+        "hourly": lexicon["frequency_hourly"],
+        "8hourly": lexicon["frequency_8hourly"],
+        "daily": lexicon["frequency_daily"],
+        "weekly": lexicon["frequency_weekly"],
+        "monthly": lexicon["frequency_monthly"],
+        "test": lexicon["frequency_test"],
+    }.get(user["frequency"], "undefined")
+    intro = lexicon["intro"].format(
+        frequency=frequency,
+        link_site=lexicon["link_site"],
+        manual_sub_count=manual_sub_count,
+        link_your_config=lexicon["link_your_config"].format(
+            link_site=lexicon["link_site"]
+        ),
+        link_info_learning=lexicon["link_info_learning"].format(
+            link_site=lexicon["link_site"]
+        ),
+        link_info_automatic=lexicon["link_info_automatic"].format(
+            link_site=lexicon["link_site"]
+        ),
+    )
+    outro = lexicon["outro"].format(
+        unsub_footer=lexicon["unsub_footer"].format(
+            link_unsubscribe=lexicon["link_unsubscribe"].format(
                 link_site=lexicon["link_site"]
-            ),
-            link_info_learning=lexicon["link_info_learning"].format(
-                link_site=lexicon["link_site"]
-            ),
-            link_info_automatic=lexicon["link_info_automatic"].format(
-                link_site=lexicon["link_site"]
-            ),
-        )
-        outro = lexicon["outro"].format(
-            unsub_footer=lexicon["unsub_footer"].format(
-                link_unsubscribe=lexicon["link_unsubscribe"].format(
-                    link_site=lexicon["link_site"]
-                )
             )
         )
-        body = lexicon["body"].format(
-            intro=intro,
-            wikis="\n".join(make_wikis_digest(posts, lexicon)),
-            outro=outro,
-        )
-        subject = pluralise(subject, lang)
-        body = finalise_digest(body, lang)
-        body = convert_syntax(body, user["delivery"])
-        return subject, body
+    )
+    body = lexicon["body"].format(
+        intro=intro,
+        wikis="\n".join(make_wikis_digest(posts, lexicon)),
+        outro=outro,
+    )
+    subject = pluralise(subject, lang)
+    body = finalise_digest(body, lang)
+    body = convert_syntax(body, user["delivery"])
+    return subject, body
 
 
 def make_wikis_digest(

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -12,7 +12,7 @@ from notifier.deletions import (
     delete_prepared_invalid_user_pages,
     rename_invalid_user_config_pages,
 )
-from notifier.digest import Digester
+from notifier.composer import Composer
 from notifier.dumps import LogDumpCacher, record_activation_log
 from notifier.emailer import Emailer
 from notifier.newposts import get_new_posts
@@ -216,7 +216,7 @@ def notify_active_channels(
     dry_run: bool = False,
 ) -> None:
     """Prepare and send notifications to all activated channels."""
-    digester = Digester(config["path"]["lang"])
+    composer = Composer(config["path"]["lang"])
     emailer = Emailer(
         config["gmail_username"], auth["gmail_password"], dry_run=dry_run
     )
@@ -228,7 +228,7 @@ def notify_active_channels(
             config=config,
             database=database,
             wikidot=wikidot,
-            digester=digester,
+            composer=composer,
             emailer=emailer,
             dry_run=dry_run,
         )
@@ -242,7 +242,7 @@ def notify_channel(
     config: LocalConfig,
     database: BaseDatabaseDriver,
     wikidot: Wikidot,
-    digester: Digester,
+    composer: Composer,
     emailer: Emailer,
     dry_run: bool = False,
 ) -> None:
@@ -299,7 +299,7 @@ def notify_channel(
                 config=config,
                 database=database,
                 wikidot=wikidot,
-                digester=digester,
+                composer=composer,
                 emailer=emailer,
                 addresses=addresses,
                 dry_run=dry_run,
@@ -364,7 +364,7 @@ def notify_user(
     config: LocalConfig,
     database: BaseDatabaseDriver,
     wikidot: Wikidot,
-    digester: Digester,
+    composer: Composer,
     emailer: Emailer,
     addresses: EmailAddresses,
     dry_run: bool = False,
@@ -424,7 +424,7 @@ def notify_user(
     last_notified_timestamp = max(post["posted_timestamp"] for post in posts)
 
     # Compile the digest
-    subject, body = digester.for_user(user, posts)
+    subject, body = composer.make_notification_digest(user, posts)
 
     if dry_run:
         logger.info(

--- a/notifier/notify.py
+++ b/notifier/notify.py
@@ -424,7 +424,7 @@ def notify_user(
     last_notified_timestamp = max(post["posted_timestamp"] for post in posts)
 
     # Compile the digest
-    subject, body = composer.make_notification_digest(user, posts)
+    subject, body = composer.write_notification_digest(user, posts)
 
     if dry_run:
         logger.info(

--- a/tests/make_sample_digest.py
+++ b/tests/make_sample_digest.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 from typing import Literal, cast
 
-from notifier.digest import Digester
+from notifier.composer import Composer
 from tests.test_digest import fake_posts, fake_user_config
 
 if __name__ == "__main__":
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     user["language"] = lang
     user["delivery"] = delivery
     posts = fake_posts()
-    digester = Digester(str(Path.cwd() / "config" / "lang.toml"))
-    subject, digest = digester.for_user(user, posts)
+    composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
+    subject, digest = composer.make_notification_digest(user, posts)
     print("Subject:", subject)
     print(digest)

--- a/tests/make_sample_digest.py
+++ b/tests/make_sample_digest.py
@@ -14,6 +14,6 @@ if __name__ == "__main__":
     user["delivery"] = delivery
     posts = fake_posts()
     composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
-    subject, digest = composer.make_notification_digest(user, posts)
+    subject, digest = composer.write_notification_digest(user, posts)
     print("Subject:", subject)
     print(digest)

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -5,7 +5,7 @@ import pytest
 
 from notifier.composer import (
     Composer,
-    finalise_digest,
+    postprocess_message,
     write_categories_digest,
     write_wikis_digest,
     pluralise,
@@ -159,7 +159,7 @@ def test_fake_digest() -> None:
     assert digest.count("Response...") == 8
 
     # Print an email output for review
-    print(convert_syntax(finalise_digest(digest, "en"), "email"))
+    print(convert_syntax(postprocess_message(digest, "en"), "email"))
 
 
 def test_full_interpolation_en() -> None:

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -3,8 +3,8 @@ from typing import List
 
 import pytest
 
-from notifier.digest import (
-    Digester,
+from notifier.composer import (
+    Composer,
     finalise_digest,
     make_wikis_digest,
     pluralise,
@@ -145,8 +145,8 @@ def test_pluralise() -> None:
 def test_fake_digest() -> None:
     """Construct a digest from fake data and compare it to the expected
     output."""
-    digester = Digester(str(Path.cwd() / "config" / "lang.toml"))
-    lexicon = digester.make_lexicon(fake_user_config["language"])
+    composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
+    lexicon = composer.make_lexicon(fake_user_config["language"])
     digest = "\n".join(make_wikis_digest(fake_posts(), lexicon))
     print(digest)
     print(digest[:25].replace("\n", "\\n"))
@@ -165,12 +165,12 @@ def test_fake_digest() -> None:
 def test_full_interpolation_en() -> None:
     """Verify that there's no leftover interpolation in the English digest."""
 
-    digester = Digester(str(Path.cwd() / "config" / "lang.toml"))
-    languages = set(digester.lexicons.keys())
+    composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
+    languages = set(composer.lexicons.keys())
     languages.remove("base")
 
     for delivery in ("email", "pm"):
-        digest = digester.for_user(
+        digest = composer.make_notification_digest(
             {
                 **fake_user_config,
                 "language": "en",
@@ -184,8 +184,8 @@ def test_full_interpolation_en() -> None:
 def test_categories_digest_duplication_bug() -> None:
     """Test that categories only show their own posts, not all posts."""
 
-    digester = Digester(str(Path.cwd() / "config" / "lang.toml"))
-    lexicon = digester.make_lexicon("en")
+    composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
+    lexicon = composer.make_lexicon("en")
 
     # Create posts in two different categories
     posts_category_1: List[PostInfo] = [
@@ -275,14 +275,14 @@ def test_categories_digest_duplication_bug() -> None:
 def test_full_interpolation_all_languages() -> None:
     """Verify that there's no leftover interpolation in any language's digest."""
 
-    digester = Digester(str(Path.cwd() / "config" / "lang.toml"))
-    languages = set(digester.lexicons.keys())
+    composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
+    languages = set(composer.lexicons.keys())
     languages.remove("base")
 
     for language in languages:
         for delivery in ("email", "pm"):
             print(language, delivery)
-            subject, body = digester.for_user(
+            subject, body = composer.make_notification_digest(
                 {
                     **fake_user_config,
                     "language": language,

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -6,14 +6,14 @@ import pytest
 from notifier.composer import (
     Composer,
     finalise_digest,
-    make_wikis_digest,
+    write_categories_digest,
+    write_wikis_digest,
     pluralise,
     process_long_lexicon_strings,
     process_long_string,
 )
 from notifier.formatter import convert_syntax
 from notifier.types import CachedUserConfig, PostInfo
-from notifier.digest import make_categories_digest
 
 
 fake_user_config: CachedUserConfig = {  # TODO Subscriptions
@@ -146,8 +146,8 @@ def test_fake_digest() -> None:
     """Construct a digest from fake data and compare it to the expected
     output."""
     composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
-    lexicon = composer.make_lexicon(fake_user_config["language"])
-    digest = "\n".join(make_wikis_digest(fake_posts(), lexicon))
+    lexicon = composer.build_lexicon(fake_user_config["language"])
+    digest = "\n".join(write_wikis_digest(fake_posts(), lexicon))
     print(digest)
     print(digest[:25].replace("\n", "\\n"))
 
@@ -170,7 +170,7 @@ def test_full_interpolation_en() -> None:
     languages.remove("base")
 
     for delivery in ("pm", "email"):
-        digest = composer.make_notification_digest(
+        digest = composer.write_notification_digest(
             {
                 **fake_user_config,
                 "language": "en",
@@ -185,7 +185,7 @@ def test_categories_digest_duplication_bug() -> None:
     """Test that categories only show their own posts, not all posts."""
 
     composer = Composer(str(Path.cwd() / "config" / "lang.toml"))
-    lexicon = composer.make_lexicon("en")
+    lexicon = composer.build_lexicon("en")
 
     # Create posts in two different categories
     posts_category_1: List[PostInfo] = [
@@ -243,7 +243,7 @@ def test_categories_digest_duplication_bug() -> None:
     ]
 
     all_posts = posts_category_1 + posts_category_2
-    categories_digest = make_categories_digest(all_posts, lexicon)
+    categories_digest = write_categories_digest(all_posts, lexicon)
     assert len(categories_digest) == 2
     category_1_digest = (
         categories_digest[0]
@@ -282,7 +282,7 @@ def test_full_interpolation_all_languages() -> None:
     for language in languages:
         for delivery in ("pm", "email"):
             print(language, delivery)
-            subject, body = composer.make_notification_digest(
+            subject, body = composer.write_notification_digest(
                 {
                     **fake_user_config,
                     "language": language,

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -169,7 +169,7 @@ def test_full_interpolation_en() -> None:
     languages = set(composer.lexicons.keys())
     languages.remove("base")
 
-    for delivery in ("email", "pm"):
+    for delivery in ("pm", "email"):
         digest = composer.make_notification_digest(
             {
                 **fake_user_config,
@@ -280,7 +280,7 @@ def test_full_interpolation_all_languages() -> None:
     languages.remove("base")
 
     for language in languages:
-        for delivery in ("email", "pm"):
+        for delivery in ("pm", "email"):
             print(language, delivery)
             subject, body = composer.make_notification_digest(
                 {


### PR DESCRIPTION
- [ ] Send a confirmation message when a new user signs up - resolves #95
- [ ] Send a confirmation message when a user changes delivery method, but only if they would not otherwise receive a notification from this run
- [ ] Send confirmations ASAP, i.e. on the hourly channel, regardless of the user's notification channel
  - This is so that I can say "expect a message in the next hour" reliably 
- [ ] Work out how to guarantee no duplicate confirmations