### PR TITLE
Mark unsubscribed users as freq=never

### DIFF
--- a/notifier/config/user.py
+++ b/notifier/config/user.py
@@ -7,7 +7,6 @@ import tomlkit
 from tomlkit.exceptions import TOMLKitError
 
 from notifier.database.drivers.base import BaseDatabaseDriver
-from notifier.database.utils import try_cache
 from notifier.parsethread import get_timestamp
 from notifier.types import (
     LocalConfig,
@@ -43,11 +42,10 @@ def get_user_config(
     wikidot: Wikidot,
 ) -> None:
     """Retrieve remote user config."""
-    try_cache(
-        get=lambda: find_valid_user_configs(local_config, wikidot),
-        store=database.store_user_configs,
-        do_not_store=[],
-    )
+    configs = find_valid_user_configs(local_config, wikidot)
+    if len(configs) == 0:
+        return
+    database.store_user_configs(configs)
 
 
 def find_valid_user_configs(

--- a/notifier/database/drivers/mysql.py
+++ b/notifier/database/drivers/mysql.py
@@ -9,7 +9,6 @@ from pymysql.cursors import DictCursor
 
 from notifier.database.drivers.base import BaseDatabaseDriver
 from notifier.database.utils import BaseDatabaseWithSqlFileCache
-from notifier.deletions import delete_posts
 from notifier.types import (
     ActivationLogDump,
     CachedUserConfig,

--- a/notifier/database/queries/delete_user_config.sql
+++ b/notifier/database/queries/delete_user_config.sql
@@ -1,4 +1,6 @@
-DELETE FROM
+UPDATE
   user_config
+SET
+  user_config.frequency = "never"
 WHERE
   user_config.user_id = %(user_id)s


### PR DESCRIPTION
Unsubscription is detected when a user is not returned in the config listpages. However, Wikidot occasionally fails to return some users from this query.

Marking users as being subscribed to the 'never' frequency effectively unsubscribes them, at the cost of their local config not being deleted should they delete their config from the config wiki.

As there is no longer a way to reliably detect this event, I consider this tradeoff to be necessary.

This resolves #116 by making the act of 'purging' user config non-destructive.